### PR TITLE
Introduce 'verify'-function for listener

### DIFF
--- a/listener/example/main.go
+++ b/listener/example/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/kyma-project/runtime-watcher/listener/pkg/event"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,7 +17,9 @@ func main() {
 	logf.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
 	})))
-	skrEvent, _ := event.RegisterListenerComponent(":8089", "example-listener")
+	skrEvent, _ := event.RegisterListenerComponent(":8089", "example-listener", func(r *http.Request) error {
+		return nil
+	})
 
 	go func() {
 		for {

--- a/listener/pkg/event/http_test.go
+++ b/listener/pkg/event/http_test.go
@@ -26,11 +26,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-func newTestListener(addr, component string, log logr.Logger) *listenerEvent.SKREventListener {
+func newTestListener(addr, component string, log logr.Logger,
+	verify func(r *http.Request) error,
+) *listenerEvent.SKREventListener {
 	return &listenerEvent.SKREventListener{
 		Addr:          addr,
 		Logger:        log,
 		ComponentName: component,
+		VerifyFunc:    verify,
 	}
 }
 
@@ -69,7 +72,9 @@ func TestHandler(t *testing.T) {
 	t.Parallel()
 	// SETUP
 	log := setupLogger()
-	skrEventsListener := newTestListener(":8082", "kyma", log)
+	skrEventsListener := newTestListener(":8082", "kyma", log, func(r *http.Request) error {
+		return nil
+	})
 
 	handlerUnderTest := skrEventsListener.HandleSKREvent()
 	responseRecorder := httptest.NewRecorder()

--- a/listener/pkg/event/skr_events_listener.go
+++ b/listener/pkg/event/skr_events_listener.go
@@ -22,7 +22,7 @@ func RegisterListenerComponent(addr, componentName string,
 		Addr:           addr,
 		ComponentName:  componentName,
 		receivedEvents: eventSource,
-		verifyFunc:     verify,
+		VerifyFunc:     verify,
 	}, &source.Channel{Source: eventSource}
 }
 
@@ -31,7 +31,7 @@ type SKREventListener struct {
 	Logger         logr.Logger
 	ComponentName  string
 	receivedEvents chan event.GenericEvent
-	verifyFunc     func(r *http.Request) error
+	VerifyFunc     func(r *http.Request) error
 }
 
 func (l *SKREventListener) GetReceivedEvents() chan event.GenericEvent {
@@ -85,7 +85,7 @@ func (l *SKREventListener) HandleSKREvent() http.HandlerFunc {
 		l.Logger.V(1).Info("received event from SKR")
 
 		// verify request
-		if err := l.verifyFunc(req); err != nil {
+		if err := l.VerifyFunc(req); err != nil {
 			l.Logger.Info("request could not be verified - Event will not be dispatched",
 				"error", err)
 			return

--- a/listener/pkg/event/skr_events_listener.go
+++ b/listener/pkg/event/skr_events_listener.go
@@ -26,6 +26,10 @@ func RegisterListenerComponent(addr, componentName string,
 	}, &source.Channel{Source: eventSource}
 }
 
+// Verify is a function which is being called to verify an incomming request to the listener.
+// If the verification fails an error should be returned and the request will be dropped,
+// otherwise it should return nil.
+// If no verification function is needed, a function which just returns nil can be used instead.
 type Verify func(r *http.Request) error
 
 type SKREventListener struct {

--- a/listener/pkg/event/skr_events_listener.go
+++ b/listener/pkg/event/skr_events_listener.go
@@ -26,12 +26,14 @@ func RegisterListenerComponent(addr, componentName string,
 	}, &source.Channel{Source: eventSource}
 }
 
+type Verify func(r *http.Request) error
+
 type SKREventListener struct {
 	Addr           string
 	Logger         logr.Logger
 	ComponentName  string
 	receivedEvents chan event.GenericEvent
-	VerifyFunc     func(r *http.Request) error
+	VerifyFunc     Verify
 }
 
 func (l *SKREventListener) GetReceivedEvents() chan event.GenericEvent {


### PR DESCRIPTION
This PR introduces a verification function which needs to be passed to the listener.
If no verification function is needed, a function which just returns 'nil' can be used instead.

This needs to be introduced to have optional verification for incoming requests in-place. An example would be having a domain-name-pinning verification algorithm before adding the event to the reconciliation queue.

Example:
https://github.com/kyma-project/lifecycle-manager/pull/321
(Please review after reviewing this PR)