### PR TITLE
Fix listener tests race conditions

### DIFF
--- a/listener/.golangci.yaml
+++ b/listener/.golangci.yaml
@@ -1,6 +1,7 @@
 linters:
   enable-all: true
   disable:
+    - musttag
     - exhaustivestruct
     - golint
     - interfacer

--- a/listener/Makefile
+++ b/listener/Makefile
@@ -8,7 +8,7 @@ IMG := $(IMG_NAME):$(DOCKER_TAG)
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-GOLANG_CI_LINT_VERSION ?= v1.46.2
+GOLANG_CI_LINT_VERSION ?= v1.51.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -37,7 +37,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: fmt vet ## Run tests.
-	go test ./... -coverprofile cover.out
+	go test ./... -v --race -coverprofile cover.out
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin

--- a/listener/example-mtls/kcp/listener/main.go
+++ b/listener/example-mtls/kcp/listener/main.go
@@ -18,7 +18,7 @@ func main() {
 	logf.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
 	})))
-	skrEvent, _ := event.RegisterListenerComponent(":8089", "example-listener",
+	skrListener, _ := event.RegisterListenerComponent(":8089", "example-listener",
 		func(r *http.Request, watcherEvtObject *types.WatchEvent) error {
 			return nil
 		})
@@ -26,7 +26,7 @@ func main() {
 	go func() {
 		for {
 			select {
-			case response := <-skrEvent.GetReceivedEvents():
+			case response := <-skrListener.ReceivedEvents:
 				logger.Info("watcher event received....")
 				logger.Info(fmt.Sprintf("%v", response.Object))
 			case <-ctx.Done():
@@ -36,7 +36,7 @@ func main() {
 		}
 	}()
 
-	if err := skrEvent.Start(ctx); err != nil {
+	if err := skrListener.Start(ctx); err != nil {
 		logger.Error(err, "cannot start listener")
 	}
 }

--- a/listener/pkg/event/http_test.go
+++ b/listener/pkg/event/http_test.go
@@ -29,8 +29,7 @@ import (
 func newTestListener(addr, component string, log logr.Logger,
 	verify listenerEvent.Verify,
 ) *listenerEvent.SKREventListener {
-	eventSource := make(chan event.GenericEvent)
-	listener := listenerEvent.NewSKREventListener(addr, component, verify, eventSource)
+	listener := listenerEvent.NewSKREventListener(addr, component, verify)
 	listener.Logger = log
 	return listener
 }

--- a/listener/pkg/event/skr_events_listener.go
+++ b/listener/pkg/event/skr_events_listener.go
@@ -17,8 +17,8 @@ import (
 const paramContractVersion = "1"
 
 func RegisterListenerComponent(addr, componentName string, verify Verify) (*SKREventListener, *source.Channel) {
-	eventSource := make(chan event.GenericEvent)
-	return NewSKREventListener(addr, componentName, verify, eventSource), &source.Channel{Source: eventSource}
+	listener := NewSKREventListener(addr, componentName, verify)
+	return listener, &source.Channel{Source: listener.ReceivedEvents}
 }
 
 // Verify is a function which is being called to verify an incomming request to the listener.
@@ -36,12 +36,11 @@ type SKREventListener struct {
 }
 
 func NewSKREventListener(addr, componentName string, verify Verify,
-	eventSource chan event.GenericEvent,
 ) *SKREventListener {
 	return &SKREventListener{
 		Addr:           addr,
 		ComponentName:  componentName,
-		ReceivedEvents: eventSource,
+		ReceivedEvents: make(chan event.GenericEvent),
 		VerifyFunc:     verify,
 	}
 }

--- a/listener/pkg/event/watcher_event_test.go
+++ b/listener/pkg/event/watcher_event_test.go
@@ -18,11 +18,11 @@ import (
 const hostname = "http://localhost:8082"
 
 type unmarshalTestCase struct {
-	name       string
-	urlPath    string
-	payload    *types.WatchEvent
-	errMsg     string
-	httpStatus int
+	name          string
+	urlPath       string
+	expectedEvent *types.WatchEvent
+	errMsg        string
+	httpStatus    int
 }
 
 func TestUnmarshalSKREvent(t *testing.T) {
@@ -50,25 +50,25 @@ func TestUnmarshalSKREvent(t *testing.T) {
 			http.StatusBadRequest,
 		},
 	}
-	for _, testCase := range testCases { //nolint:paralleltest
+	for idx := range testCases {
+		testCase := testCases[idx]
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
+			t.Logf("Testing %q for %q", testCase.name, testCase.urlPath)
 			// GIVEN
 			url := fmt.Sprintf("%s%s", hostname, testCase.urlPath)
 			req := newListenerRequest(t, http.MethodPost, url, testWatcherEvt)
 			// WHEN
-			watcherEvent, err := listenerEvent.UnmarshalSKREvent(req)
+			currentWatcherEvent, err := listenerEvent.UnmarshalSKREvent(req)
 			// THEN
 			if err != nil {
 				require.Equal(t, testCase.errMsg, err.Message)
 				require.Equal(t, testCase.httpStatus, err.HTTPErrorCode)
 				return
 			}
-			genericEvtObject := listenerEvent.GenericEvent(watcherEvent)
 			require.Equal(t, testCase.errMsg, "")
 			require.Equal(t, testCase.httpStatus, http.StatusOK)
-			testcasePayloadContent := listenerEvent.UnstructuredContent(testCase.payload)
-			require.Equal(t, testcasePayloadContent, genericEvtObject.Object)
+			require.Equal(t, testCase.expectedEvent, currentWatcherEvent)
 		})
 	}
 }


### PR DESCRIPTION
**Proposed changes**
- Export listener event channel to fix a race condition in the tests
- Refactor parallel tests' design to using an indexed range loop to execute all the test cases and not only the last test case.