### PR TITLE
Fix MiddleWare Body Bug + Small improvements

### DIFF
--- a/listener/pkg/event/skr_events_listener.go
+++ b/listener/pkg/event/skr_events_listener.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -83,6 +84,7 @@ func (l *SKREventListener) RequestSizeLimitingMiddleware(next http.HandlerFunc) 
 
 		if request.ContentLength > requestSizeLimitInBytes {
 			errorMessage := fmt.Sprintf("Body size greater than %d bytes is not allowed", requestSizeLimitInBytes)
+			l.Logger.Error(errors.New("requestSizeExceeded"), errorMessage)
 			http.Error(writer, errorMessage, http.StatusRequestEntityTooLarge)
 			return
 		}

--- a/listener/pkg/event/skr_events_listener.go
+++ b/listener/pkg/event/skr_events_listener.go
@@ -2,9 +2,7 @@ package event
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -82,12 +80,9 @@ func (l *SKREventListener) Start(ctx context.Context) error {
 
 func (l *SKREventListener) RequestSizeLimitingMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		_, err := io.ReadAll(request.Body)
 
-		if request.ContentLength > requestSizeLimitInBytes ||
-			errors.Is(err, &http.MaxBytesError{Limit: requestSizeLimitInBytes}) {
+		if request.ContentLength > requestSizeLimitInBytes {
 			errorMessage := fmt.Sprintf("Body size greater than %d bytes is not allowed", requestSizeLimitInBytes)
-			l.Logger.Error(err, errorMessage)
 			http.Error(writer, errorMessage, http.StatusRequestEntityTooLarge)
 			return
 		}

--- a/listener/pkg/event/watcher_event.go
+++ b/listener/pkg/event/watcher_event.go
@@ -45,7 +45,8 @@ func UnmarshalSKREvent(req *http.Request) (*types.WatchEvent, *UnmarshalError) {
 	watcherEvent := &types.WatchEvent{}
 	err = json.Unmarshal(body, watcherEvent)
 	if err != nil {
-		return nil, &UnmarshalError{fmt.Sprintf("could not unmarshal watcher event: Body %s", body), http.StatusInternalServerError}
+		return nil, &UnmarshalError{fmt.Sprintf("could not unmarshal watcher event: Body{%s}",
+			string(body)), http.StatusInternalServerError}
 	}
 
 	return watcherEvent, nil

--- a/listener/pkg/event/watcher_event.go
+++ b/listener/pkg/event/watcher_event.go
@@ -45,7 +45,7 @@ func UnmarshalSKREvent(req *http.Request) (*types.WatchEvent, *UnmarshalError) {
 	watcherEvent := &types.WatchEvent{}
 	err = json.Unmarshal(body, watcherEvent)
 	if err != nil {
-		return nil, &UnmarshalError{"could not unmarshal watcher event", http.StatusInternalServerError}
+		return nil, &UnmarshalError{fmt.Sprintf("could not unmarshal watcher event: Body %s", body), http.StatusInternalServerError}
 	}
 
 	return watcherEvent, nil

--- a/skr/go.mod
+++ b/skr/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0
-	github.com/kyma-project/runtime-watcher/listener v0.0.0-20230131092109-31657012720d
+	github.com/kyma-project/runtime-watcher/listener v0.0.0-20230619090337-a68fd69e7295
 	github.com/onsi/ginkgo/v2 v2.8.3
 	github.com/onsi/gomega v1.27.1
 	k8s.io/api v0.26.1

--- a/skr/go.sum
+++ b/skr/go.sum
@@ -348,6 +348,8 @@ github.com/kyma-project/runtime-watcher/listener v0.0.0-20220905120552-de040bdde
 github.com/kyma-project/runtime-watcher/listener v0.0.0-20220905120552-de040bddeba1/go.mod h1:B9EIzs4QqcDpGmaTB6MdmF51FWMVQPEDxkiHEGGQVyo=
 github.com/kyma-project/runtime-watcher/listener v0.0.0-20230131092109-31657012720d h1:1PfddHO/y5kp64waLf1Omv/J7HPoAS2TNquuTUjIskk=
 github.com/kyma-project/runtime-watcher/listener v0.0.0-20230131092109-31657012720d/go.mod h1:KGeHsh0+joeAq7/0ssR6pj7G55gDC3y4CCvtZeofHOI=
+github.com/kyma-project/runtime-watcher/listener v0.0.0-20230619090337-a68fd69e7295 h1:eaLZBxvQcZNaeovL39EDG21nKSiiJ1o1ZJ3NQskz+Ik=
+github.com/kyma-project/runtime-watcher/listener v0.0.0-20230619090337-a68fd69e7295/go.mod h1:KGeHsh0+joeAq7/0ssR6pj7G55gDC3y4CCvtZeofHOI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/skr/internal/handler.go
+++ b/skr/internal/handler.go
@@ -360,12 +360,13 @@ func (h *Handler) sendRequestToKcp(moduleName string, watched ObjectWatched) str
 
 	resp, err := httpClient.Post(url, "application/json", requestPayload)
 	if err != nil {
-		h.Logger.Error(err, KcpReqFailedMsg, "payload", requestPayload)
+		h.Logger.Error(err, KcpReqFailedMsg, "postBody", postBody)
 		return KcpReqFailedMsg
 	}
 	defer resp.Body.Close()
 	responseBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
+		h.Logger.Error(err, KcpReqFailedMsg, "postBody", postBody)
 		h.Logger.Error(err, fmt.Sprintf("responseBody: %s with StatusCode: %d", responseBody, resp.StatusCode))
 		return KcpReqFailedMsg
 	}
@@ -452,6 +453,6 @@ func (h *Handler) getHTTPClientAndURL(uri string) (http.Client, string, error) {
 	}
 
 	url := fmt.Sprintf("%s://%s", protocol, uri)
-	h.Logger.Info("KCP", "url", url)
+	h.Logger.Info("KCP Address", "url", url)
 	return httpClient, url, nil
 }


### PR DESCRIPTION
- Upgrade to latest listener pkg version in skr watcher
- Fix remove `Read Body` in Middleware, otherwise Buffer would be empty, thus event cannot be unmarshaled. It is sufficient to just check size
- Include more details in error logs