### PR TITLE
Add explicit watcher version

### DIFF
--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.21-alpine as builder
 ARG BUILD_VERSION=from-Dockerfile
 
 RUN printenv | sed 's/=.*//g'
+RUN echo TAG_default_tag=${TAG_default_tag}
 
 WORKDIR /app
 

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -10,10 +10,10 @@ RUN go mod download
 COPY main.go main.go
 COPY internal/ internal/
 
-# TAG_DEFAULT_TAG comes from image builder: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder
-ARG TAG_DEFAULT_TAG=from_dockerfile
+# TAG_default_tag comes from image builder: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder
+ARG TAG_default_tag=from_dockerfile
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_DEFAULT_TAG}'" -a -o webhook main.go 
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_default_tag}'" -a -o webhook main.go 
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21-alpine as builder
 ARG BUILD_VERSION=from-Dockerfile
 
 RUN printenv | sed 's/=.*//g'
-RUN echo TAG_default_tag=${TAG_default_tag}
+RUN echo TAG_BUILD_VERSION=${TAG_BUILD_VERSION}
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN go mod download
 COPY main.go main.go
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${BUILD_VERSION}'" -a -o webhook main.go 
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_BUILD_VERSION}'" -a -o webhook main.go 
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.21-alpine as builder
 ARG BUILD_VERSION=from-Dockerfile
 
+RUN printenv | sed 's/=.*//g'
+
 WORKDIR /app
 
 COPY go.mod go.mod

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.21-alpine as builder
+ARG BUILD_VERSION=from-Dockerfile
 
 WORKDIR /app
-
-RUN printenv | sed 's/=.+/./g'
 
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -12,7 +11,7 @@ RUN go mod download
 COPY main.go main.go
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o webhook main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${BUILD_VERSION}'" -a -o webhook main.go 
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -11,7 +11,9 @@ COPY main.go main.go
 COPY internal/ internal/
 
 # TAG_DEFAULT_TAG comes from image builder: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_DEFAULT_TAG:-from_dockerfile}'" -a -o webhook main.go 
+ARG TAG_DEFAULT_TAG=from_dockerfile
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_DEFAULT_TAG}'" -a -o webhook main.go 
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.21-alpine as builder
 
 WORKDIR /app
 
+RUN printenv | sed 's/=.+/./g'
+
 COPY go.mod go.mod
 COPY go.sum go.sum
 

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -1,8 +1,4 @@
 FROM golang:1.21-alpine as builder
-ARG BUILD_VERSION=from-Dockerfile
-
-RUN printenv | sed 's/=.*//g'
-RUN echo TAG_BUILD_VERSION=${TAG_BUILD_VERSION}
 
 WORKDIR /app
 
@@ -14,7 +10,8 @@ RUN go mod download
 COPY main.go main.go
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_BUILD_VERSION}'" -a -o webhook main.go 
+# TAG_DEFAULT_TAG comes from image builder: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_DEFAULT_TAG:-from_dockerfile}'" -a -o webhook main.go 
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -3,6 +3,7 @@ APP_NAME = runtime-watcher-skr
 IMG_REPO := $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)
 IMG_NAME := $(IMG_REPO)/$(APP_NAME)
 IMG := $(IMG_NAME):$(DOCKER_TAG)
+BUILD_VERSION := from-makefile
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
@@ -62,7 +63,7 @@ test: fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: fmt vet ## Build runtime-watcher binary.
-	go build -o bin/webhook main.go
+	go build -ldflags="-X 'main.buildVersion=${BUILD_VERSION}'" -o bin/webhook main.go 
 
 .PHONY: run
 run: fmt vet ## Run runtime-watcher from your host.

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -3,7 +3,7 @@ APP_NAME = runtime-watcher-skr
 IMG_REPO := $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)
 IMG_NAME := $(IMG_REPO)/$(APP_NAME)
 IMG := $(IMG_NAME):$(DOCKER_TAG)
-BUILD_VERSION := from-makefile
+BUILD_VERSION := from_makefile
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1

--- a/runtime-watcher/main.go
+++ b/runtime-watcher/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kyma-project/runtime-watcher/skr/internal/serverconfig"
 )
 
+//nolint:gochecknoglobals
 var buildVersion = "not-provided"
 
 func main() {

--- a/runtime-watcher/main.go
+++ b/runtime-watcher/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/kyma-project/runtime-watcher/skr/internal/parser"
 
@@ -33,13 +34,24 @@ import (
 	"github.com/kyma-project/runtime-watcher/skr/internal/serverconfig"
 )
 
+var buildVersion string = "unknown"
+
 func main() {
+	var printVersion bool
+	flag.BoolVar(&printVersion, "version", false, "Prints the watcher version and exits")
+
 	logger := ctrl.Log.WithName("skr-webhook")
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if printVersion {
+		fmt.Printf("Runtime Watcher version: %s\n", buildVersion)
+		os.Exit(1)
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	config, err := serverconfig.ParseFromEnv(logger)

--- a/runtime-watcher/main.go
+++ b/runtime-watcher/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/kyma-project/runtime-watcher/skr/internal/serverconfig"
 )
 
-var buildVersion string = "unknown"
+var buildVersion string = "not-provided"
 
 func main() {
 	var printVersion bool
@@ -53,6 +53,8 @@ func main() {
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	logger.Info("starting the Runtime Watcher", "Version:", buildVersion)
 
 	config, err := serverconfig.ParseFromEnv(logger)
 	if err != nil {

--- a/runtime-watcher/main.go
+++ b/runtime-watcher/main.go
@@ -35,7 +35,7 @@ import (
 )
 
 //nolint:gochecknoglobals
-var buildVersion = "not-provided"
+var buildVersion = "not_provided"
 
 func main() {
 	var printVersion bool

--- a/runtime-watcher/main.go
+++ b/runtime-watcher/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/kyma-project/runtime-watcher/skr/internal/serverconfig"
 )
 
-var buildVersion string = "not-provided"
+var buildVersion = "not-provided"
 
 func main() {
 	var printVersion bool
@@ -48,8 +48,12 @@ func main() {
 	flag.Parse()
 
 	if printVersion {
-		fmt.Printf("Runtime Watcher version: %s\n", buildVersion)
-		os.Exit(1)
+		msg := fmt.Sprintf("Runtime Watcher version: %s\n", buildVersion)
+		_, err := os.Stdout.WriteString(msg)
+		if err != nil {
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))


### PR DESCRIPTION
**Description**

As part of https://github.com/kyma-project/runtime-watcher/issues/134, every released watcher binary should have an explicit version that corresponds to git commit hash.

Changes proposed in this pull request:

- log the version at watcher startup
- provide a new flag `-version` that prints the version and exits
- extend the Makefile to build the binary with an explicit version
- extend the Dockerfile to build the docker image with an explicit version

**Related issue(s)**
#134 