### PR TITLE
chore: Bump go version and golangci-lint

### DIFF
--- a/.github/workflows/pull-runtime-watcher.yml
+++ b/.github/workflows/pull-runtime-watcher.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54.2
+          version: v1.56.2
           args: --verbose
           working-directory: ./runtime-watcher
       - name: Build

--- a/listener/Makefile
+++ b/listener/Makefile
@@ -8,7 +8,7 @@ IMG := $(IMG_NAME):$(DOCKER_TAG)
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-GOLANG_CI_LINT_VERSION ?= v1.54.1
+GOLANG_CI_LINT_VERSION ?= v1.56.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/listener/go.mod
+++ b/listener/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/listener
 
-go 1.21.1
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -12,7 +12,7 @@ BUILD_VERSION := from_makefile
 ENVTEST_K8S_VERSION = 1.24.1
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
-GOLANG_CI_LINT_VERSION ?= v1.54.2
+GOLANG_CI_LINT_VERSION ?= v1.56.2
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin

--- a/runtime-watcher/go.mod
+++ b/runtime-watcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/skr
 
-go 1.21.1
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Upgrade go version used in tests to 1.22
- Upgrade go version in go.mod to 1.22
- Upgrade golangci-lint version used by make lint target to v1.56.2
- Upgrade golangci-lint version used by GHA lint workflow to v1.56.2

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
