### PR TITLE
deps: Bump sec-scanners-config watcher img tag to 1.1.1

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,7 +1,7 @@
 module-name: runtime-watcher
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/runtime-watcher-skr:latest
-  - europe-docker.pkg.dev/kyma-project/prod/runtime-watcher-skr:1.0.0
+  - europe-docker.pkg.dev/kyma-project/prod/runtime-watcher-skr:1.1.1
 whitesource:
   language: golang-mod
   exclude:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Set sec-scanner-config img tag version to last release 1.1.1

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
