### PR TITLE
chore: Bump go version to 1.22.6

### DIFF
--- a/listener/go.mod
+++ b/listener/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/listener
 
-go 1.22.4
+go 1.22.6
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/runtime-watcher/go.mod
+++ b/runtime-watcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/skr
 
-go 1.22.4
+go 1.22.6
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Bumps go version in `go.mod` to 1.22.6. This resolves e2e test errors as in https://github.com/kyma-project/runtime-watcher/pull/342 (tested via https://github.com/kyma-project/runtime-watcher/pull/343)

Dockerfiles already use `FROM golang:1.22.6-alpine as builder`