### PR TITLE
feat: Add GitHub Action Workflow for Runtime Watcher Image Build

### DIFF
--- a/.github/workflows/build-runtime-watcher.yml
+++ b/.github/workflows/build-runtime-watcher.yml
@@ -1,0 +1,35 @@
+name: build-runtime-watcher
+
+on:
+  push:
+    branches:
+      - main  # This will get tagged with `latest` and `v{{DATE}}-{{COMMIT_HASH_SHORT}}`
+  pull_request_target:
+    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
+jobs:
+  compute-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get_tag.outputs.TAG }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get the latest tag
+        id: get_tag
+        if: github.event_name == 'push'
+        run: echo "tag=latest" >> $GITHUB_OUTPUT
+      - name: Echo the tag
+        run: echo ${{ steps.get_tag.outputs.TAG }}
+  build-image:
+    needs: compute-tag
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: template-operator
+      dockerfile: ./runtime-watcher/Dockerfile
+      context: .
+      tags: ${{ needs.compute-tag.outputs.tag }}

--- a/.github/workflows/build-runtime-watcher.yml
+++ b/.github/workflows/build-runtime-watcher.yml
@@ -29,7 +29,7 @@ jobs:
     needs: compute-tag
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
-      name: template-operator
+      name: runtime-watcher
       dockerfile: ./runtime-watcher/Dockerfile
       context: .
       tags: ${{ needs.compute-tag.outputs.tag }}


### PR DESCRIPTION
**Description**
This PR aims to make this runtime-watcher repository use GitHub Actions for building images, dropping dependency on Prow Jobs for image builds.

**Related Issues**
- Resolves a part of [this issue](https://github.com/kyma-project/lifecycle-manager/issues/1811)
- Implementation in support of [this issue](https://github.com/kyma-project/lifecycle-manager/issues/1811)