### PR TITLE
fix: Make e2e reuse build image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,8 +11,6 @@ on:
         required: false
         type: string
         default: ""
-  pull_request_target:
-    types: [ opened, edited, synchronize, reopened, ready_for_review ]
 
 permissions:
   id-token: write # This is required for requesting the JWT token

--- a/.github/workflows/test-e2e-runtime-watcher.yml
+++ b/.github/workflows/test-e2e-runtime-watcher.yml
@@ -6,15 +6,15 @@ on:
       k8s_version:
         description: With Kubernetes version
         required: false
-  workflow_run:
-    workflows: ["Build Image"]
-    types:
-      - completed
-    branches-ignore:
-      - main
+  pull_request_target:
+    types: [ opened, edited, synchronize, reopened, ready_for_review ]
 jobs:
+  build-image:
+    name: Build Image
+    uses: ./.github/workflows/build-image.yml
   e2e-integration:
     name: E2E
+    needs: build-image
     strategy:
       matrix:
         e2e-test:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Although `workflow_run` can trigger e2e workflow, it's not referenced by PR, which make e2e tests impossible test based on PR.  

This PR refactored workflow dependencies by using build image in e2e workflow.
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
