### PR TITLE
chore: Bump go versions to 1.23.2

### DIFF
--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -1,5 +1,5 @@
 ## Run from root context!!
-FROM golang:1.22.7-alpine as builder
+FROM golang:1.23.2-alpine as builder
 
 WORKDIR /app
 

--- a/listener/go.mod
+++ b/listener/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/listener
 
-go 1.22.6
+go 1.23.2
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.7-alpine as builder
+FROM golang:1.23.2-alpine as builder
 
 WORKDIR /app
 

--- a/runtime-watcher/go.mod
+++ b/runtime-watcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/skr
 
-go 1.22.6
+go 1.23.2
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump go version to latest 1.23.2 for listener and runtime-watcher components

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
