### PR TITLE
docs: Fix watched-by label description and example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,14 +18,14 @@ spec:
 
 ### **spec.labelsToWatch**
 
-> **NOTE:** The resources you're watching must have the `operator.kyma-project.io/watched-by` label. The label also informs where to route requests to.
+> **NOTE:** The resources you're watching must have the `operator.kyma-project.io/watched-by` label.
 
 With the **spec.labelsToWatch** attribute, you can filter the specified Group/Version/Kind (GVK) in **spec.resourceToWatch**. For example, if the specified GVK is `secrets`, then it is useful to filter them by a specific label, otherwise, the Runtime Watcher would send an event to the KCP for every Create/Read/Update/Delete (CRUD) event of any Secret in the Kyma cluster.
 
 ```yaml
 spec:
   labelsToWatch:
-    "operator.kyma-project.io/watched-by": "lifecycle-manager"
+    "operator.kyma-project.io/watched-by": "kyma"
     "example.label.to.watch": "true"
   resourceToWatch:
     group: ""


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- removes the description that the watched-by label defines where requests are routed to as this is not correct
  - the most up to date description how it works is here: https://github.com/kyma-project/lifecycle-manager/issues/1940 and includes an AC to come up with proper documentation once we fixed the approach
- updates the example to use `kyma` as label value

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
