### PR TITLE
chore: Add "contents: write" Permission to Create Release Workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,6 +1,7 @@
 name: "Create release"
 
-permissions: { }
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- This is a hotfix for the "Create Release" workflow. It needs the contents: write permission to create a tag on the repository.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- closes: https://github.com/kyma-project/lifecycle-manager/issues/2263
