### PR TITLE
chore: Remove unnecessary dependabot label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,6 @@ updates:
         - "/listener"
         - "/runtime-watcher"
     labels:
-      - "docker"
       - "area/dependency"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove setting of label `docker` in dependabot PRs
- The label does not exist in our repos and results in dependabot comment on dependabot PRs
- The label is not needed 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
