### PR TITLE
chore: Bump runtime-watcher to 1.1.16 in security scanners config

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -5,7 +5,7 @@ checkmarx-one:
   exclude:
     - "**/*_test.go"
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/runtime-watcher:1.1.15
+  - europe-docker.pkg.dev/kyma-project/prod/runtime-watcher:1.1.16
   - europe-docker.pkg.dev/kyma-project/prod/runtime-watcher:latest
 mend:
   language: golang-mod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump runtime-watcher to 1.1.16 in security scanners config

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
