### PR TITLE
chore: Add Content-Security-Policy header

### DIFF
--- a/runtime-watcher/internal/handler.go
+++ b/runtime-watcher/internal/handler.go
@@ -68,6 +68,9 @@ func NewHandler(logger logr.Logger,
 const (
 	strictTransportSecurityHeader = "Strict-Transport-Security"
 	strictTransportSecurityValue  = "max-age=31536000; includeSubDomains"
+
+	contentSecurityPolicy      = "Content-Security-Policy"
+	contentSecurityPolicyValue = "default-src 'self'"
 )
 
 func (h *Handler) Handle(writer http.ResponseWriter, request *http.Request) {
@@ -99,6 +102,7 @@ func (h *Handler) Handle(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	writer.Header().Set(strictTransportSecurityHeader, strictTransportSecurityValue)
+	writer.Header().Set(contentSecurityPolicy, contentSecurityPolicyValue)
 	if _, err = writer.Write(responseBytes); err != nil {
 		h.logger.Error(err, admissionError)
 		return

--- a/runtime-watcher/internal/handler_test.go
+++ b/runtime-watcher/internal/handler_test.go
@@ -123,6 +123,7 @@ var _ = Describe("given watched resource", Ordered, func() {
 		Expect(admissionReview.Response.Result.Message).To(Equal(testCase.results.resultMsg))
 		Expect(admissionReview.Response.Result.Status).To(Equal(testCase.results.resultStatus))
 		Expect(skrRecorder.Header().Get("Strict-Transport-Security")).To(Equal("max-age=31536000; includeSubDomains"))
+		Expect(skrRecorder.Header().Get("Content-Security-Policy")).To(Equal("default-src 'self'"))
 
 		// check listener event
 		Expect(kcpRecorder.Code).To(BeEquivalentTo(http.StatusOK))


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- adds `Content-Security-Policy` header to fix `kyma/security-scans-modular/issues/135834`
- value is set to `default-src 'self'` to enforce that only content from our host itself can be fetched
  - we do not have a requirement to load other content like scripts, images, styles, etc. anyway

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
