### PR TITLE
fix(Dockerfile): Allow multi-arch image build

### DIFF
--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4-alpine as builder
 
 WORKDIR /app
 
@@ -12,8 +12,10 @@ COPY internal/ internal/
 
 # TAG_default_tag comes from image builder: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder
 ARG TAG_default_tag=from_dockerfile
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.buildVersion=${TAG_default_tag}'" -a -o webhook main.go 
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X 'main.buildVersion=${TAG_default_tag}'" -a -o webhook main.go
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Modify Dockerfile for runtime-watcher to allow multi-arch image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
