### PR TITLE
chore: Bump lifecycle-manager/api version

### DIFF
--- a/runtime-watcher/go.mod
+++ b/runtime-watcher/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/uuid v1.6.0
-	github.com/kyma-project/lifecycle-manager/api v0.0.0-20250611085322-84921a030c13
+	github.com/kyma-project/lifecycle-manager/api v0.0.0-20250725134740-2be609ec0693
 	github.com/kyma-project/runtime-watcher/listener v0.0.0-20250317130058-42ef0a646046
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.38.0
@@ -35,7 +35,7 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/runtime-watcher/go.sum
+++ b/runtime-watcher/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -64,6 +66,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyma-project/lifecycle-manager/api v0.0.0-20250611085322-84921a030c13 h1:82m+dbx0vFyQuSMDGo1gUHH6J57i1EmWNvOg4Ld8B40=
 github.com/kyma-project/lifecycle-manager/api v0.0.0-20250611085322-84921a030c13/go.mod h1:au6zvCDD6NNi67sHllwcMdsjNQ19ynhS7HX4JKSxXso=
+github.com/kyma-project/lifecycle-manager/api v0.0.0-20250725134740-2be609ec0693 h1:cTJNMStKU7NhplowzZOrkLivRJjbMd+3p7GmmzX7/oU=
+github.com/kyma-project/lifecycle-manager/api v0.0.0-20250725134740-2be609ec0693/go.mod h1:Vmb5XezfomlADmP3aqwZxXzYU3BOPMd3jitmaNU4N6w=
 github.com/kyma-project/runtime-watcher/listener v0.0.0-20250317130058-42ef0a646046 h1:03g/tseSGYf0Ob1ZP4qLHxHyqxBEFT0NjVP5frduRGE=
 github.com/kyma-project/runtime-watcher/listener v0.0.0-20250317130058-42ef0a646046/go.mod h1:JTkqD1px7OKETXWbXvBqGcZoaKw96S3J+6t/TlKFfNM=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update lifecycle-manager/api version to the [1.3.12](https://github.com/kyma-project/lifecycle-manager/releases/tag/1.3.12)