### PR TITLE
chore: Limit buildx of image-builder workflow to amd64 arch only

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -46,6 +46,8 @@ jobs:
       name: runtime-watcher
       dockerfile: Dockerfile
       context: ./runtime-watcher
+      platforms: |
+        linux/amd64
       # tags are additional tags that will be added to the image on top of the default ones
       # default tags are documented here: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder#default-tags
       tags: ${{ needs.get-custom-tags.outputs.tags }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- see https://github.com/kyma-project/lifecycle-manager/pull/2613

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
