### PR TITLE
chore: Read lint and envtest from version file

### DIFF
--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -16,6 +16,7 @@ runs:
       working-directory: runtime-watcher
       shell: bash
       run: |
+        pwd
         cat versions.yaml
         echo "golangci_lint_version=$(yq e '.golangciLint' versions.yaml)" >> $GITHUB_OUTPUT
     - name: Expose environment variables

--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -7,13 +7,8 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout lifecycle-manager
-      uses: actions/checkout@v4
-      with:
-        repository: kyma-project/lifecycle-manager
-        path: lifecycle-manager
     - name: Install yq
-      uses: kyma-project/lifecycle-manager/.github/actions/install-yq
+      uses: kyma-project/lifecycle-manager/.github/actions/install-yq@main
       with:
         yq_version: 4.45.1
     - name: Define variables

--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -13,11 +13,10 @@ runs:
         yq_version: 4.45.1
     - name: Define variables
       id: define-variables
-      working-directory: runtime-watcher
       shell: bash
       run: |
         pwd
-        cat versions.yaml
+        cat ./../versions.yaml
         echo "golangci_lint_version=$(yq e '.golangciLint' versions.yaml)" >> $GITHUB_OUTPUT
     - name: Expose environment variables
       shell: bash

--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
       run: |
         pwd
-        cat ./../versions.yaml
+        cat versions.yaml
         echo "golangci_lint_version=$(yq e '.golangciLint' versions.yaml)" >> $GITHUB_OUTPUT
     - name: Expose environment variables
       shell: bash

--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -7,6 +7,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Checkout lifecycle-manager
+      uses: actions/checkout@v4
+      with:
+        repository: kyma-project/lifecycle-manager
+        path: lifecycle-manager
     - name: Install yq
       uses: kyma-project/lifecycle-manager/.github/actions/install-yq
       with:

--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -1,0 +1,23 @@
+name: configuration
+description: Defines configuration variables such as versions read from the versions.yaml file. Exposes globally needed environment variables.
+outputs:
+  golangci_lint_version:
+    description: The version of golangci-lint to use. For example, 1.60.3.
+    value: ${{ steps.define-variables.outputs.golangci_lint_version }}
+runs:
+  using: composite
+  steps:
+    - name: Install yq
+      uses: kyma-project/lifecycle-manager/.github/actions/install-yq
+      with:
+        yq_version: 4.45.1
+    - name: Define variables
+      id: define-variables
+      working-directory: runtime-watcher
+      shell: bash
+      run: |
+        echo "golangci_lint_version=$(yq e '.golangciLint' versions.yaml)" >> $GITHUB_OUTPUT
+    - name: Expose environment variables
+      shell: bash
+      run: |
+        echo "GOSUMDB=off" >> $GITHUB_ENV

--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -16,6 +16,7 @@ runs:
       working-directory: runtime-watcher
       shell: bash
       run: |
+        cat versions.yaml
         echo "golangci_lint_version=$(yq e '.golangciLint' versions.yaml)" >> $GITHUB_OUTPUT
     - name: Expose environment variables
       shell: bash

--- a/.github/workflows/pull-listener-pkg.yml
+++ b/.github/workflows/pull-listener-pkg.yml
@@ -16,10 +16,13 @@ jobs:
         with:
           go-version-file: 'listener/go.mod'
           cache-dependency-path: 'listener/go.sum'
+      - name: Get configuration
+        uses: ./runtime-watcher/.github/actions/configuration
+        id: configuration
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v${{ steps.configuration.outputs.golangci_lint_version }}
           args: --verbose
           working-directory: ./listener
       - name: Build

--- a/.github/workflows/pull-listener-pkg.yml
+++ b/.github/workflows/pull-listener-pkg.yml
@@ -17,7 +17,7 @@ jobs:
           go-version-file: 'listener/go.mod'
           cache-dependency-path: 'listener/go.sum'
       - name: Get configuration
-        uses: ./runtime-watcher/.github/actions/configuration
+        uses: ./../../listener/.github/actions/configuration
         id: configuration
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0

--- a/.github/workflows/pull-listener-pkg.yml
+++ b/.github/workflows/pull-listener-pkg.yml
@@ -17,7 +17,7 @@ jobs:
           go-version-file: 'listener/go.mod'
           cache-dependency-path: 'listener/go.sum'
       - name: Get configuration
-        uses: ./../listener/.github/actions/configuration
+        uses: ./../runtime-watcher/.github/actions/configuration
         id: configuration
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0

--- a/.github/workflows/pull-listener-pkg.yml
+++ b/.github/workflows/pull-listener-pkg.yml
@@ -17,7 +17,7 @@ jobs:
           go-version-file: 'listener/go.mod'
           cache-dependency-path: 'listener/go.sum'
       - name: Get configuration
-        uses: ./../../listener/.github/actions/configuration
+        uses: ./../listener/.github/actions/configuration
         id: configuration
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0

--- a/.github/workflows/pull-runtime-watcher.yml
+++ b/.github/workflows/pull-runtime-watcher.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           go-version-file: 'runtime-watcher/go.mod'
           cache-dependency-path: 'runtime-watcher/go.sum'
+      - name: Get configuration
+        uses: ./runtime-watcher/.github/actions/configuration
+        id: configuration
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:

--- a/.github/workflows/pull-runtime-watcher.yml
+++ b/.github/workflows/pull-runtime-watcher.yml
@@ -17,12 +17,12 @@ jobs:
           go-version-file: 'runtime-watcher/go.mod'
           cache-dependency-path: 'runtime-watcher/go.sum'
       - name: Get configuration
-        uses: ./runtime-watcher/.github/actions/configuration
+        uses: ./../runtime-watcher/.github/actions/configuration
         id: configuration
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v${{ steps.configuration.outputs.golangci_lint_version }}
           args: --verbose
           working-directory: ./runtime-watcher
       - name: Build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# Make target to run both lint targets from ./listener and ./runtime-watcher
+.PHONY: lint-all
+lint-all: lint-runtime-watcher lint-listener
+
+.PHONY: lint-runtime-watcher
+lint-runtime-watcher: ## Run golangci-lint against runtime-watcher code.
+	$(MAKE) -C runtime-watcher lint
+
+.PHONY: lint-listener
+lint-listener: ## Run golangci-lint against listener code.
+	$(MAKE) -C listener lint

--- a/listener/.golangci.yaml
+++ b/listener/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - sqlclosecheck
     - wastedassign
     - wsl
+    - wsl_v5 # needs to be discussed with the team if enforced grouping of statements is desired, but generally too strict
   settings:
     cyclop:
       max-complexity: 20

--- a/listener/.golangci.yaml
+++ b/listener/.golangci.yaml
@@ -15,7 +15,7 @@ linters:
     - sqlclosecheck
     - wastedassign
     - wsl
-    - wsl_v5 # needs to be discussed with the team if enforced grouping of statements is desired, but generally too strict
+    - wsl_v5 # can be discussed with the team if enforced grouping of statements is desired, but generally considered too strict
   settings:
     cyclop:
       max-complexity: 20

--- a/listener/Makefile
+++ b/listener/Makefile
@@ -4,11 +4,8 @@ IMG_REPO := $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)
 IMG_NAME := $(IMG_REPO)/$(APP_NAME)
 IMG := $(IMG_NAME):$(DOCKER_TAG)
 
-## Tool Binaries
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
-
-## Tool Versions
-GOLANG_CI_LINT_VERSION ?= v2.1.6
+GOLANG_CI_LINT_VERSION ?= v$(shell yq e '.golangciLint' ./../versions.yaml)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/listener/pkg/event/skr_events_listener.go
+++ b/listener/pkg/event/skr_events_listener.go
@@ -113,7 +113,8 @@ func (l *SKREventListener) HandleSKREvent() http.HandlerFunc {
 		}
 
 		// verify request
-		if err := l.VerifyFunc(req, watcherEvent); err != nil {
+		err := l.VerifyFunc(req, watcherEvent)
+		if err != nil {
 			metrics.RecordHTTPFailedVerificationRequests(req.RequestURI)
 			l.Logger.Info("request could not be verified - Event will not be dispatched",
 				"error", err)

--- a/runtime-watcher/.golangci.yaml
+++ b/runtime-watcher/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - sqlclosecheck
     - wastedassign
     - wsl
+    - wsl_v5 # needs to be discussed with the team if enforced grouping of statements is desired, but generally too strict
   settings:
     cyclop:
       max-complexity: 20

--- a/runtime-watcher/.golangci.yaml
+++ b/runtime-watcher/.golangci.yaml
@@ -15,7 +15,7 @@ linters:
     - sqlclosecheck
     - wastedassign
     - wsl
-    - wsl_v5 # needs to be discussed with the team if enforced grouping of statements is desired, but generally too strict
+    - wsl_v5 # can be discussed with the team if enforced grouping of statements is desired, but generally considered too strict
   settings:
     cyclop:
       max-complexity: 20

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -48,10 +48,6 @@ tidy: ## Run go mod tidy against code.
 test: fmt vet envtest ## Run unit and envtest.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test `go list ./... | grep -v /tests/` -coverprofile cover.out -coverpkg=./...
 
-.PHONY: envtest-dir
-envtest-dir:
-	echo "$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)"
-
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -47,9 +47,14 @@ tidy: ## Run go mod tidy against code.
 test: fmt vet envtest ## Run unit and envtest.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test `go list ./... | grep -v /tests/` -coverprofile cover.out -coverpkg=./...
 
-envtest: $(ENVTEST) ## Install envtest.
+.PHONY: envtest-dir
+envtest-dir:
+	echo "$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)"
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-$(ENVTEST_VERSION)
 
 lint: ## Run golangci-lint against code.
 	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -9,10 +9,11 @@ IMG_REPO := $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)
 IMG_NAME := $(IMG_REPO)/$(APP_NAME)
 IMG := $(IMG_NAME):$(DOCKER_TAG)
 BUILD_VERSION := from_makefile
-ENVTEST_K8S_VERSION = 1.24.1
+ENVTEST_K8S_VERSION = $(shell yq e '.envtest_k8s' ./../versions.yaml)
+ENVTEST_VERSION = $(shell yq e '.envtest' ./../versions.yaml)
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
-GOLANG_CI_LINT_VERSION ?= v2.1.6
+GOLANG_CI_LINT_VERSION ?= v$(shell yq e '.golangciLint' ./../versions.yaml)
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -47,9 +48,14 @@ tidy: ## Run go mod tidy against code.
 test: fmt vet envtest ## Run unit and envtest.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test `go list ./... | grep -v /tests/` -coverprofile cover.out -coverpkg=./...
 
-envtest: $(ENVTEST) ## Install envtest.
+.PHONY: envtest-dir
+envtest-dir:
+	echo "$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)"
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-$(ENVTEST_VERSION)
 
 lint: ## Run golangci-lint against code.
 	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -9,10 +9,10 @@ IMG_REPO := $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)
 IMG_NAME := $(IMG_REPO)/$(APP_NAME)
 IMG := $(IMG_NAME):$(DOCKER_TAG)
 BUILD_VERSION := from_makefile
-ENVTEST_K8S_VERSION = $(shell yq e '.envtest_k8s' ./../versions.yaml)
-ENVTEST_VERSION = $(shell yq e '.envtest' ./../versions.yaml)
+ENVTEST_K8S_VERSION = 1.24.1
+ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
-GOLANG_CI_LINT_VERSION ?= v$(shell yq e '.golangciLint' ./../versions.yaml)
+GOLANG_CI_LINT_VERSION ?= v2.1.6
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -47,14 +47,9 @@ tidy: ## Run go mod tidy against code.
 test: fmt vet envtest ## Run unit and envtest.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test `go list ./... | grep -v /tests/` -coverprofile cover.out -coverpkg=./...
 
-.PHONY: envtest-dir
-envtest-dir:
-	echo "$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)"
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+envtest: $(ENVTEST) ## Install envtest.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-$(ENVTEST_VERSION)
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 lint: ## Run golangci-lint against code.
 	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -9,8 +9,8 @@ IMG_REPO := $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)
 IMG_NAME := $(IMG_REPO)/$(APP_NAME)
 IMG := $(IMG_NAME):$(DOCKER_TAG)
 BUILD_VERSION := from_makefile
-ENVTEST_K8S_VERSION = $(shell yq e '.envtest_k8s' ./versions.yaml)
-ENVTEST_VERSION = $(shell yq e '.envtest' ./versions.yaml)
+ENVTEST_K8S_VERSION = $(shell yq e '.envtest_k8s' ./../versions.yaml)
+ENVTEST_VERSION = $(shell yq e '.envtest' ./../versions.yaml)
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
 GOLANG_CI_LINT_VERSION ?= v$(shell yq e '.golangciLint' ./../versions.yaml)
 

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -9,10 +9,10 @@ IMG_REPO := $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)
 IMG_NAME := $(IMG_REPO)/$(APP_NAME)
 IMG := $(IMG_NAME):$(DOCKER_TAG)
 BUILD_VERSION := from_makefile
-ENVTEST_K8S_VERSION = 1.24.1
-ENVTEST ?= $(LOCALBIN)/setup-envtest
+ENVTEST_K8S_VERSION = $(shell yq e '.envtest_k8s' ./versions.yaml)
+ENVTEST_VERSION = $(shell yq e '.envtest' ./versions.yaml)
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
-GOLANG_CI_LINT_VERSION ?= v2.1.6
+GOLANG_CI_LINT_VERSION ?= v$(shell yq e '.golangciLint' ./../versions.yaml)
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin

--- a/runtime-watcher/internal/cacertificatehandler/ca_certificate_handler_test.go
+++ b/runtime-watcher/internal/cacertificatehandler/ca_certificate_handler_test.go
@@ -123,7 +123,8 @@ func writeCertificatesToFile(certFile *os.File, certificateCount int) error {
 		certs = append(certs, certBytes...)
 	}
 
-	if _, err := certFile.Write(certs); err != nil {
+	_, err := certFile.Write(certs)
+	if err != nil {
 		certFile.Close()
 		return fmt.Errorf("failed to write certificates to file: %w", err)
 	}

--- a/runtime-watcher/internal/handler.go
+++ b/runtime-watcher/internal/handler.go
@@ -103,7 +103,8 @@ func (h *Handler) Handle(writer http.ResponseWriter, request *http.Request) {
 
 	writer.Header().Set(strictTransportSecurityHeader, strictTransportSecurityValue)
 	writer.Header().Set(contentSecurityPolicy, contentSecurityPolicyValue)
-	if _, err = writer.Write(responseBytes); err != nil {
+	_, err = writer.Write(responseBytes)
+	if err != nil {
 		h.logger.Error(err, admissionError)
 		return
 	}
@@ -207,7 +208,8 @@ var (
 )
 
 func (h *Handler) unmarshalWatchedObject(rawBytes []byte, response responseInterface) {
-	if err := json.Unmarshal(rawBytes, response); err != nil {
+	err := json.Unmarshal(rawBytes, response)
+	if err != nil {
 		h.logger.Error(errors.Join(errAdmission, err), "failed to unmarshal admission review resource object")
 	}
 	if response.IsEmpty() {

--- a/runtime-watcher/internal/handler_util_test.go
+++ b/runtime-watcher/internal/handler_util_test.go
@@ -49,6 +49,7 @@ var (
 
 type CustomRouter struct {
 	*http.ServeMux
+
 	Recorder *httptest.ResponseRecorder
 }
 

--- a/runtime-watcher/internal/requestparser/parser.go
+++ b/runtime-watcher/internal/requestparser/parser.go
@@ -32,7 +32,8 @@ func (rp *RequestParser) ParseAdmissionReview(request *http.Request) (*admission
 	}
 
 	admissionReview := &admissionv1.AdmissionReview{}
-	if _, _, err = rp.deserializer.Decode(bodyBytes, nil, admissionReview); err != nil {
+	_, _, err = rp.deserializer.Decode(bodyBytes, nil, admissionReview)
+	if err != nil {
 		return nil, errors.Join(errDeserializeRequestBody, err)
 	}
 	if admissionReview.Request == nil {

--- a/runtime-watcher/internal/serverconfig/config.go
+++ b/runtime-watcher/internal/serverconfig/config.go
@@ -42,7 +42,8 @@ func ParseFromEnv(logger logr.Logger) (ServerConfig, error) {
 		if err != nil {
 			logger.Error(err, flagError(envWebhookPort).Error())
 		}
-		if err = validatePortRange(port); err != nil {
+		err = validatePortRange(port)
+		if err != nil {
 			logger.Error(err, flagError(envWebhookPort).Error())
 		} else {
 			config.Port = port
@@ -55,7 +56,8 @@ func ParseFromEnv(logger logr.Logger) (ServerConfig, error) {
 		if err != nil {
 			logger.Error(err, flagError(envMetricsPort).Error())
 		}
-		if err = validatePortRange(port); err != nil {
+		err = validatePortRange(port)
+		if err != nil {
 			logger.Error(err, flagError(envMetricsPort).Error())
 		} else {
 			config.MetricsPort = port

--- a/runtime-watcher/internal/types.go
+++ b/runtime-watcher/internal/types.go
@@ -8,7 +8,8 @@ import (
 
 type Resource struct {
 	metav1.GroupVersionKind `json:"groupVersionKind"`
-	SubResource             string `json:"subResource"`
+
+	SubResource string `json:"subResource"`
 }
 
 type Metadata struct {
@@ -27,7 +28,8 @@ func (m Metadata) NamespacedName() string {
 }
 
 type WatchedObject struct {
-	Metadata   `json:"metadata"`
+	Metadata `json:"metadata"`
+
 	Spec       map[string]interface{} `json:"spec"`
 	APIVersion string                 `json:"apiVersion"`
 	Kind       string                 `json:"kind"`

--- a/runtime-watcher/tests/e2e/e2e_after_test.go
+++ b/runtime-watcher/tests/e2e/e2e_after_test.go
@@ -47,13 +47,15 @@ func cleanupKymaAfterAll(kyma *v1beta2.Kyma) {
 }
 
 func removePurgeFinalizerAndDeleteKyma(ctx context.Context, clnt client.Client, kyma *v1beta2.Kyma) error {
-	if err := syncKyma(ctx, clnt, kyma); err != nil {
+	err := syncKyma(ctx, clnt, kyma)
+	if err != nil {
 		return fmt.Errorf("sync kyma %w", err)
 	}
 	if !kyma.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(kyma, shared.PurgeFinalizer) {
 			controllerutil.RemoveFinalizer(kyma, shared.PurgeFinalizer)
-			if err := clnt.Update(ctx, kyma); err != nil {
+			err := clnt.Update(ctx, kyma)
+			if err != nil {
 				return fmt.Errorf("can't remove purge finalizer %w", err)
 			}
 		}

--- a/runtime-watcher/tests/e2e/e2e_before_test.go
+++ b/runtime-watcher/tests/e2e/e2e_before_test.go
@@ -112,7 +112,8 @@ func CRIsInState(ctx context.Context, clnt client.Client, name types.NamespacedN
 func GetCR(ctx context.Context, clnt client.Client, name types.NamespacedName, gvk schema.GroupVersionKind) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
-	if err := clnt.Get(ctx, name, obj); err != nil {
+	err := clnt.Get(ctx, name, obj)
+	if err != nil {
 		return nil, err
 	}
 	return obj, nil

--- a/runtime-watcher/tests/e2e/utils/logassert.go
+++ b/runtime-watcher/tests/e2e/utils/logassert.go
@@ -94,7 +94,8 @@ func fetchLogsFromPod(ctx context.Context,
 ) (string, error) {
 	pod := apicorev1.Pod{}
 	podList := &apicorev1.PodList{}
-	if err := clnt.List(ctx, podList, &client.ListOptions{Namespace: namespace}); err != nil {
+	err := clnt.List(ctx, podList, &client.ListOptions{Namespace: namespace})
+	if err != nil {
 		return "", fmt.Errorf("failed to list pods %w", err)
 	}
 

--- a/runtime-watcher/tests/e2e/utils/metrics.go
+++ b/runtime-watcher/tests/e2e/utils/metrics.go
@@ -14,13 +14,15 @@ import (
 
 func ExposeSKRMetricsServiceEndpoint() error {
 	cmd := exec.Command("kubectl", "config", "use-context", "k3d-skr")
-	if _, err := cmd.CombinedOutput(); err != nil {
+	_, err := cmd.CombinedOutput()
+	if err != nil {
 		return fmt.Errorf("failed to switch context %w", err)
 	}
 
 	cmd = exec.Command("kubectl", "patch", "svc", "skr-webhook-metrics", "-p",
 		"{\"spec\": {\"type\": \"LoadBalancer\"}}", "-n", "kyma-system")
-	if _, err := cmd.CombinedOutput(); err != nil {
+	_, err = cmd.CombinedOutput()
+	if err != nil {
 		return fmt.Errorf("failed to patch metrics service %w", err)
 	}
 

--- a/runtime-watcher/tests/e2e/utils/utils.go
+++ b/runtime-watcher/tests/e2e/utils/utils.go
@@ -83,7 +83,8 @@ func AddSkipReconciliationLabelToKyma(ctx context.Context, clnt client.Client, k
 	}
 
 	kyma.Labels[shared.SkipReconcileLabel] = "true"
-	if err := clnt.Update(ctx, kyma); err != nil {
+	err = clnt.Update(ctx, kyma)
+	if err != nil {
 		return fmt.Errorf("failed to update kyma, %w", err)
 	}
 
@@ -100,7 +101,8 @@ func RemoveKymaAnnotations(ctx context.Context, clnt client.Client,
 	}
 
 	kyma.Annotations = nil
-	if err := clnt.Update(ctx, kyma); err != nil {
+	err = clnt.Update(ctx, kyma)
+	if err != nil {
 		return fmt.Errorf("failed to update kyma, %w", err)
 	}
 	return nil

--- a/runtime-watcher/tests/e2e/watcher_enqueue_test.go
+++ b/runtime-watcher/tests/e2e/watcher_enqueue_test.go
@@ -157,7 +157,8 @@ func deleteDeployment(ctx context.Context, k8sClient client.Client, name Resourc
 
 func deploymentReady(ctx context.Context, clnt client.Client, name ResourceName) error {
 	deployment := &apiappsv1.Deployment{}
-	if err := clnt.Get(ctx, name, deployment); err != nil {
+	err := clnt.Get(ctx, name, deployment)
+	if err != nil {
 		return err
 	}
 	if deployment.Status.ReadyReplicas != 1 {
@@ -192,9 +193,10 @@ func deleteSecret(ctx context.Context, clnt client.Client, name ResourceName) er
 
 func changeRemoteKymaChannel(ctx context.Context, clnt client.Client, channel string) error {
 	kyma := &v1beta2.Kyma{}
-	if err := clnt.Get(ctx,
+	err := clnt.Get(ctx,
 		client.ObjectKey{Name: defaultRemoteKymaName, Namespace: remoteNamespace},
-		kyma); err != nil {
+		kyma)
+	if err != nil {
 		return err
 	}
 
@@ -216,7 +218,8 @@ func updateRemoteKymaStatus(clnt client.Client) error {
 		LastUpdateTime: apimetav1.NewTime(time.Now()),
 	}
 	kyma.ManagedFields = nil
-	if err := clnt.Status().Update(ctx, kyma); err != nil {
+	err = clnt.Status().Update(ctx, kyma)
+	if err != nil {
 		return fmt.Errorf("kyma status subresource could not be updated: %w", err)
 	}
 
@@ -232,7 +235,8 @@ func updateWatcherSpecField(ctx context.Context, k8sClient client.Client) error 
 		return fmt.Errorf("failed to get Kyma %w", err)
 	}
 	watcherCR.Spec.Field = v1beta2.StatusField
-	if err = k8sClient.Update(ctx, watcherCR); err != nil {
+	err = k8sClient.Update(ctx, watcherCR)
+	if err != nil {
 		return fmt.Errorf("failed to update watcher spec.field: %w", err)
 	}
 	return nil

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,0 +1,3 @@
+golangciLint: "2.1.6"
+envtest: "0.21"
+envtest_k8s: "1.32.0"

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,3 +1,3 @@
-golangciLint: "2.1.6"
+golangciLint: "2.3.1"
 envtest: "0.21"
 envtest_k8s: "1.32.0"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add versions.yaml similar to lifecycle-manager to read linter version and envtests versions from
- Remaining tooling versions are already read from lifecycle-manager repo for E2E tests: https://github.com/kyma-project/runtime-watcher/blob/2f4e759e706f60b8dea27674699176cde980c729/.github/workflows/test-e2e-runtime-watcher.yml#L53
- Also bump the linter version to: `2.3.1` (with excluded new linter, that does not bring improvements over the old version)
- Add Makefile for root to call both `listener` and `runtime-watcher` lint targets with:
`make lint-all`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
