### PR TITLE
feat: Add fips 140 metric

### DIFF
--- a/runtime-watcher/internal/watchermetrics/godebug.go
+++ b/runtime-watcher/internal/watchermetrics/godebug.go
@@ -4,24 +4,32 @@ import (
 	"strings"
 )
 
-func parseGodebugFipsMode(s string) string {
-	result := "off"
+// parseGodebugFipsMode parses the provided value to determine the FIPS mode.
+// The argument to this function should be a value of the GODEBUG environment variable.
+// We need to parse it manually because the provided fips140.Enabled() function doesn't distinguish
+// between "on", "debug" and "only" modes.
+func parseGodebugFipsMode(goDebugEnvVar string) string {
+	const off = "off"
 
-	if len(s) == 0 {
+	result := off
+
+	if len(goDebugEnvVar) == 0 {
 		return result
 	}
-	for keyValuePair := range strings.SplitSeq(s, ",") {
+	for keyValuePair := range strings.SplitSeq(goDebugEnvVar, ",") {
 		keyValuePair = strings.TrimSpace(keyValuePair)
-		if !strings.HasPrefix(keyValuePair, "fips140=") {
-			continue
+		if justValue := strings.TrimPrefix(keyValuePair, "fips140="); len(justValue) < len(keyValuePair) {
+			result = justValue
+			// We're not leaving the loop here to align with the Go standard library parsing logic,
+			// where "the last provided value wins"
 		}
-		result = strings.TrimPrefix(keyValuePair, "fips140=")
 	}
 	switch result {
-	case "off", "on", "debug", "only":
+	case off, "on", "debug", "only":
 		return result
 	default:
-		// if the value is not one of the expected values, we return "off"
-		return "off"
+		// If the value is not one of the expected values, return "off" to have exhaustive matching.
+		// Go standard library panics in this case.
+		return off
 	}
 }

--- a/runtime-watcher/internal/watchermetrics/godebug.go
+++ b/runtime-watcher/internal/watchermetrics/godebug.go
@@ -1,0 +1,27 @@
+package watchermetrics
+
+import (
+	"strings"
+)
+
+func parseGodebugFipsMode(s string) string {
+	result := "off"
+
+	if len(s) == 0 {
+		return result
+	}
+	for keyValuePair := range strings.SplitSeq(s, ",") {
+		keyValuePair = strings.TrimSpace(keyValuePair)
+		if !strings.HasPrefix(keyValuePair, "fips140=") {
+			continue
+		}
+		result = strings.TrimPrefix(keyValuePair, "fips140=")
+	}
+	switch result {
+	case "off", "on", "debug", "only":
+		return result
+	default:
+		// if the value is not one of the expected values, we return "off"
+		return "off"
+	}
+}

--- a/runtime-watcher/internal/watchermetrics/godebug_internal_test.go
+++ b/runtime-watcher/internal/watchermetrics/godebug_internal_test.go
@@ -1,0 +1,33 @@
+package watchermetrics
+
+import (
+	"crypto/fips140"
+	"testing"
+)
+
+func TestParseGodebugFips140only(t *testing.T) {
+	t.Logf("FIPS: %v", fips140.Enabled())
+
+	tests := []struct {
+		godebug string
+		want    string
+	}{
+		{"fips140=only", "only"},
+		{"fips140=on", "on"},
+		{"fips140=debug", "debug"},
+		{"fips140=off", "off"},
+		{"fips140=someOtherValue", "off"}, // Such a value is refused by standard library at runtime, but here let's just default to "off"
+		{"fips140=debug, fips140=only", "only"},
+		{"fips140=off,fips140=on,fips140=only", "only"},  // The last one wins
+		{"fips140=only, fips140=on, fips140=off", "off"}, // Spaces around values should not affect the result
+		{"fips140=only , fips140=off ,fips140=on", "on"}, // Spaces around values should not affect the result
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.godebug, func(t *testing.T) {
+			if got := parseGodebugFipsMode(tt.godebug); got != tt.want {
+				t.Errorf("parseGodebugFips140only(%q) = %v, want %v", tt.godebug, got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime-watcher/internal/watchermetrics/godebug_internal_test.go
+++ b/runtime-watcher/internal/watchermetrics/godebug_internal_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func TestParseGodebugFips140only(t *testing.T) {
-	t.Logf("FIPS: %v", fips140.Enabled())
+	t.Parallel()
+	t.Logf("FIPS: %v", fips140.Enabled()) // TODO: Remove
 
 	tests := []struct {
 		godebug string
@@ -25,6 +26,7 @@ func TestParseGodebugFips140only(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.godebug, func(t *testing.T) {
+			t.Parallel()
 			if got := parseGodebugFipsMode(tt.godebug); got != tt.want {
 				t.Errorf("parseGodebugFips140only(%q) = %v, want %v", tt.godebug, got, tt.want)
 			}

--- a/runtime-watcher/internal/watchermetrics/metrics.go
+++ b/runtime-watcher/internal/watchermetrics/metrics.go
@@ -1,9 +1,10 @@
 package watchermetrics
 
 import (
+	"crypto/fips140"
 	"os"
 	"time"
-	"crypto/fips140"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -79,7 +80,7 @@ func (w *WatcherMetrics) UpdateRequestDuration(duration time.Duration) {
 func (w *WatcherMetrics) UpdateFipsMode() {
 	fipsMode := 0
 	if fips140.Enabled() {
-		if parseGodebugFipsMode(os.Getenv("GODEBUG")) == "only"{
+		if parseGodebugFipsMode(os.Getenv("GODEBUG")) == "only" {
 			fipsMode = 2 // FIPS 140-3 only mode
 		} else {
 			fipsMode = 1 // FIPS 140-3 enabled

--- a/runtime-watcher/tests/e2e/utils/metrics.go
+++ b/runtime-watcher/tests/e2e/utils/metrics.go
@@ -77,6 +77,16 @@ func GetAdmissionRequestsMetric(ctx context.Context) (int, error) {
 	return parseCount(regex, metricsBody)
 }
 
+func GetFips140Metric(ctx context.Context) (int, error) {
+	metricsBody, err := getMetricsBody(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	regex := regexp.MustCompile(`watcher_fips_mode (\d+)`)
+	return parseCount(regex, metricsBody)
+}
+
 func getMetricsBody(ctx context.Context) (string, error) {
 	clnt := &http.Client{}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:2112/metrics", nil)

--- a/runtime-watcher/tests/e2e/watcher_metrics_test.go
+++ b/runtime-watcher/tests/e2e/watcher_metrics_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Watcher Metrics", Ordered, func() {
 			By("And FIPS-140 metric indicates \"mode==enabled\"", func() {
 				Eventually(GetFips140Metric).
 					WithContext(ctx).
-					Should(BeNumerically("==", 1))
+					Should(BeNumerically("==", 2))
 			})
 		})
 

--- a/runtime-watcher/tests/e2e/watcher_metrics_test.go
+++ b/runtime-watcher/tests/e2e/watcher_metrics_test.go
@@ -52,6 +52,12 @@ var _ = Describe("Watcher Metrics", Ordered, func() {
 					WithContext(ctx).
 					Should(BeNumerically(">", 0))
 			})
+
+			By("And FIPS-140 metric indicates \"mode==enabled\"", func() {
+				Eventually(GetFips140Metric).
+					WithContext(ctx).
+					Should(BeNumerically("==", 1))
+			})
 		})
 
 		It("When kyma does not have owned by annotation", func() {


### PR DESCRIPTION
**Description**

This PR adds a new metrics that reports the current ["fips mode" ](https://go.dev/doc/security/fips140#fips-140-3-mode) of the runtime-watcher process.
The new metric name is: `foo` and the numeric values are:
- 0 for `off`
- 1 for `on`
- 2 for `only`

Changes proposed in this pull request:

- Introduce new metrics
- ...
- ...

**Related issue(s)**
https://github.com/kyma-project/lifecycle-manager/issues/2599