### PR TITLE
chore: Bump Go to 1.25.1; golangci-lint to 2.4.0

### DIFF
--- a/listener/Makefile
+++ b/listener/Makefile
@@ -49,7 +49,10 @@ $(LOCALBIN):
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
+.PHONY: install-golangci-lint
+install-golangci-lint:
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANG_CI_LINT_VERSION)
+
 .PHONY: lint
-lint: ## Run golangci-lint against code.
-	GOBIN=$(LOCALBIN) GOFIPS140=v1.0.0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)
+lint: install-golangci-lint ## Run golangci-lint against code.
 	$(LOCALBIN)/golangci-lint run -v -c .golangci.yaml

--- a/listener/go.mod
+++ b/listener/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/listener
 
-go 1.24.6
+go 1.25.1
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/runtime-watcher/Makefile
+++ b/runtime-watcher/Makefile
@@ -53,8 +53,12 @@ envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) GOFIPS140=v1.0.0 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-$(ENVTEST_VERSION)
 
-lint: ## Run golangci-lint against code.
-	GOBIN=$(LOCALBIN) GOFIPS140=v1.0.0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)
+.PHONY: install-golangci-lint
+install-golangci-lint:
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANG_CI_LINT_VERSION)
+
+.PHONY: lint
+lint: install-golangci-lint ## Run golangci-lint against code.
 	$(LOCALBIN)/golangci-lint run -v -c .golangci.yaml
 
 run: fmt vet ## Run runtime-watcher from your host.

--- a/runtime-watcher/go.mod
+++ b/runtime-watcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/skr
 
-go 1.24.6
+go 1.25.1
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,3 +1,3 @@
-golangciLint: "2.3.1"
+golangciLint: "2.4.0"
 envtest: "0.21"
 envtest_k8s: "1.32.0"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- bumps Go to 1.25.1
- bumps golangci-lint to 2.4.0
- installs golangci-lint from binary

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
