### PR TITLE
feat: Add ghcr.io image builder for local arm64 testing

### DIFF
--- a/.github/workflows/build-image-local.yml
+++ b/.github/workflows/build-image-local.yml
@@ -1,11 +1,11 @@
-name: Image Builder (Local / ghcr.io)
+name: Build Image (Local testing / ghcr.io)
 
 # Builds and publishes runtime-watcher images to ghcr.io/kyma-project for fast
 # local testing, especially on Apple M-series (arm64) machines.
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths-ignore:
       - "docs/**"
       - "**/*.md"
@@ -31,8 +31,6 @@ permissions: {}
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Skip draft PRs — only build when the PR is ready for review.
-    if: github.event.pull_request.draft == false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/image-builder-local.yml
+++ b/.github/workflows/image-builder-local.yml
@@ -1,0 +1,99 @@
+name: Image Builder (Local / ghcr.io)
+
+# Builds and publishes runtime-watcher images to ghcr.io/kyma-project for fast
+# local testing, especially on Apple M-series (arm64) machines.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".reuse/**"
+      - "LICENSES/**"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".reuse/**"
+      - "LICENSES/**"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Additional image tag (e.g. v1.2.3 or my-feature)"
+        required: false
+        default: ""
+
+permissions: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    # Skip draft PRs — only build when the PR is ready for review.
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      # QEMU provides arm64 emulation on the amd64 GitHub-hosted runner.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tag strategy:
+      #   PR            → pr-<number>  and  sha-<short>
+      #   push to main  → latest       and  sha-<short>
+      #   manual        → <input-tag>  and  sha-<short>   (sha only if no input)
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ghcr.io/kyma-project/runtime-watcher
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request_target' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' }}
+            type=sha,format=short
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: ./runtime-watcher
+          file: ./runtime-watcher/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Align TAG_default_tag with the Dockerfile ARG used by the official builder.
+          build-args: |
+            TAG_default_tag=${{ github.event.pull_request.head.sha || github.sha }}
+          # GitHub Actions cache keeps layer rebuilds fast across PR pushes.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Print published image
+        run: |
+          echo "### Published image" >> "$GITHUB_STEP_SUMMARY"
+          echo "Digest: \`${{ steps.build.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tags:" >> "$GITHUB_STEP_SUMMARY"
+          echo '${{ steps.meta.outputs.tags }}' | while read tag; do
+            echo "- \`${tag}\`" >> "$GITHUB_STEP_SUMMARY"
+          done


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/image-builder-local.yml` to build and publish `runtime-watcher` images to `ghcr.io/kyma-project/runtime-watcher`
- Supports `linux/amd64` and `linux/arm64` in a single BuildKit job (OCI manifest list — no tag collision)
- Triggers on `pull_request_target` (non-draft) and `push` to `main`; manual dispatch with optional tag
- Permissions scoped to job level only (`contents: read` + `packages: write`)
- GHA layer cache (`type=gha`) for fast repeat builds


Build context is `./runtime-watcher` (subdirectory), matching the existing `build-image.yml`.

Part of the pattern established in kyma-project/lifecycle-manager#3190.

**Related issue** #709