### PR TITLE
chore: Bump Go version to `1.26.2`

### DIFF
--- a/listener/go.mod
+++ b/listener/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/listener
 
-go 1.26.1
+go 1.26.2
 
 retract v1.1.18 // reason: not a valid release
 

--- a/runtime-watcher/go.mod
+++ b/runtime-watcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/skr
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/runtime-watcher/tests/go.mod
+++ b/runtime-watcher/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/tests
 
-go 1.26.1
+go 1.26.2
 
 replace (
 	github.com/kyma-project/runtime-watcher/listener => ../../listener


### PR DESCRIPTION
**Description**

Update Go version to `1.26.2` in `go.mod` in the `listener`, `skr` and `runtime-watcher/tests` modules

Changes proposed in this pull request:

- Bump go version to `1.26.2`

