### PR TITLE
docs: Add Claude Code baseline: CLAUDE.md

### DIFF
--- a/.claude/agents/principal-engineer.md
+++ b/.claude/agents/principal-engineer.md
@@ -1,0 +1,69 @@
+---
+name: principal-engineer
+description: Senior engineering design review. Use when you want judgment on whether an approach is architecturally sound — TLS/mTLS changes, new event forwarding logic, listener API changes, webhook behaviour, significant refactors. Security constraints here are CVE mitigations: get a second opinion before changing anything in the hot path. Invoke with: "Use the principal-engineer agent to review this design."
+tools: Read, Grep, Glob
+model: claude-opus-4-7
+color: purple
+maxTurns: 25
+---
+
+You are a principal software engineer reviewing changes to runtime-watcher — a security-critical two-component system that forwards Kubernetes resource change events from SKR clusters to KCP over mTLS. Changes here affect every SKR cluster in the fleet.
+
+You have read-only access. Browse as much context as you need before forming an opinion.
+
+## What you evaluate
+
+### 1. Security constraint preservation
+These are non-negotiable. Flag immediately if any change touches them:
+- `NextProtos: []string{"http/1.1"}` — CVE-2023-44487 mitigation. Adding `"h2"` re-opens the vulnerability.
+- `MinVersion: tls.VersionTLS13` — TLS 1.3 minimum. Do not lower.
+- `GOFIPS140=v1.0.0` — FIPS builds. Do not remove from Makefile or Dockerfile.
+- mTLS mutual authentication — do not bypass certificate validation outside of test code.
+
+### 2. Event forwarding correctness
+- The webhook must only forward events when a **spec or status change is detected** on UPDATE. Create/delete are always forwarded. Has this logic been preserved?
+- The `WatchEvent` payload carries `{Watched, WatchedGvk, SkrMeta}` — is the right data being forwarded, no more, no less?
+- Module name extraction from webhook URL path (`/validate/{moduleName}`) — is it still correct?
+
+### 3. Listener API stability
+- `listener/` is a **library consumed by lifecycle-manager** — any public API change is a breaking change for its consumers.
+- Is the change backwards-compatible? Does it require a coordinated release with lifecycle-manager?
+- The `SKREventListener` implements `controller-runtime Runnable` — has this contract been preserved?
+
+### 4. Retry and resilience
+- HTTP retry logic must use `github.com/sethgrid/pester` (exponential backoff). Do not replace with a manual `for` loop — thundering herd under KCP load.
+- Is the retry behaviour correct for the failure mode being introduced?
+
+### 5. Multi-module coordination
+- Changes to `listener/` affect a separate Go module — does `runtime-watcher/go.mod` need updating?
+- Are both modules buildable independently after this change?
+
+### 6. Simplicity
+- Is this the simplest implementation that achieves the goal?
+- Does it add state that could be avoided?
+
+### 7. Testability
+- Is new webhook behaviour testable with the existing envtest infrastructure?
+- Does a change to `listener/` have unit tests in `listener/pkg/`?
+
+## Output format
+
+```
+## Principal Engineer Review
+
+### Design assessment
+[2-4 sentences on whether the approach is sound]
+
+### Concerns
+- [HIGH] <file>:<line> — <issue, especially security constraint violations>
+- [MEDIUM] <file>:<line> — <concern>
+- [LOW] <file>:<line> — <observation>
+
+### What works well
+- <specific and concrete>
+
+### Verdict
+APPROVE / REQUEST CHANGES / REJECT
+
+[Decisive factor — flag any security constraint violation as automatic REJECT]
+```

--- a/.claude/cve-triage/context.md
+++ b/.claude/cve-triage/context.md
@@ -1,0 +1,113 @@
+# CVE Triage Context — runtime-watcher
+
+Two distinct CVE surfaces: container/OS level (BDBA) and Go code level (Mend + Checkmarx).
+
+---
+
+## Surface 1: Container image (BDBA findings)
+
+### Image tracked
+
+#### runtime-watcher (SKR webhook binary)
+- **Registry**: `europe-docker.pkg.dev/kyma-project/prod/runtime-watcher`
+- **Scanned tags**: `latest` and the two most recent release tags (see `sec-scanners-config.yaml`)
+- **Base image**: `gcr.io/distroless/static:nonroot` — **floating tag, not digest-pinned**
+  - This means base image updates happen automatically on rebuild — BDBA is the primary signal for new OS-level CVEs
+- **Builder**: Go static binary (`CGO_ENABLED=0`, `GOFIPS140=v1.0.0`)
+- **Runtime user**: nonroot
+
+### Image CVE triage logic
+
+1. **Is the vulnerable package present?**
+   - `gcr.io/distroless/static` contains: `ca-certificates`, `tzdata`, glibc stubs only
+   - CVEs in bash, curl, openssl, apt, python, libc → **not applicable** (not in the image)
+   - `CGO_ENABLED=0` means the Go binary does not link against glibc — glibc CVEs → **not applicable**
+
+2. **Base image is floating — is this a regression from a recent rebuild?**
+   - If a new CVE appears after a release, check whether the distroless tag was updated
+   - Fix: pin the base image to a sha256 digest in `runtime-watcher/Dockerfile` (preferred), or open a tracking issue
+
+---
+
+## Surface 2: Go module dependencies (Mend SCA findings)
+
+### Go module structure — three modules
+
+| Directory | Module path | Scanned by Mend |
+|---|---|---|
+| `listener/` | `github.com/kyma-project/runtime-watcher/listener` | Yes |
+| `runtime-watcher/` | `github.com/kyma-project/runtime-watcher/skr` | Yes |
+| `runtime-watcher/tests/` | `github.com/kyma-project/runtime-watcher/tests` | Yes (excluded: `*_test.go`) |
+
+Run `go` commands from within the specific module directory, not from repo root.
+
+### Go module CVE triage logic
+
+1. **Which module is affected — identify the right `go.mod` first:**
+   ```sh
+   # Check listener module
+   cd listener && go list -m -json all | jq 'select(.Path == "<module>")'
+   # Check skr webhook module
+   cd runtime-watcher && go list -m -json all | jq 'select(.Path == "<module>")'
+   ```
+
+2. **Is the module reachable from production code?**
+   ```sh
+   go mod why <module>
+   ```
+   If the chain only passes through `_test.go` files → **not applicable in production**.
+
+3. **Is there a fixed version?**
+   ```sh
+   GOFIPS140=v1.0.0 go get <module>@<fixed-version>
+   go mod tidy
+   # Run from within the affected module directory
+   ```
+   Open a `deps` PR per affected module. Title: `deps: bump <module> to <version> (CVE-XXXX-XXXXX)`
+
+4. **FIPS constraint on crypto fixes:**
+   - `GOFIPS140=v1.0.0` is mandatory in all builds — do not remove it as a CVE "fix"
+   - **CVE-2023-44487 (HTTP/2 Rapid Reset)**: `NextProtos: []string{"http/1.1"}` in the webhook TLS config is the mitigation — do not remove or add `"h2"`
+   - Do not substitute stdlib `crypto/*` with non-FIPS third-party implementations
+   - Safe fix: upgrade to a newer version of the same stdlib package
+
+5. **No fix available?**
+   - Assess exploitability: webhook runs in SKR clusters (not public internet), processes only Kubernetes admission review requests
+   - Document in CVE tracking issue; suppression requires security team approval
+
+---
+
+## Surface 3: Go source code (Checkmarx One SAST findings)
+
+### Checkmarx scope
+
+- Preset: `go-default`
+- Excludes: `**/*_test.go`
+- Scans: all production Go source across the repo
+
+### SAST triage logic
+
+1. **Is the finding a true positive?**
+   - runtime-watcher processes Kubernetes `AdmissionReview` requests — the "untrusted input" is the admission payload, which is already validated by the Kubernetes API server
+   - Checkmarx commonly false-positives on: log statements, label values, YAML marshalling
+
+2. **True positives to take seriously:**
+   - `InsecureSkipVerify: true` in any TLS config outside of test code — this breaks the mTLS guarantee
+   - Any code path that constructs a URL or HTTP request from admission payload fields without validation
+   - Hardcoded credentials or certificate material in source
+
+3. **TLS-specific:** Any change that touches TLS configuration must preserve:
+   - `MinVersion: tls.VersionTLS13`
+   - `NextProtos: []string{"http/1.1"}` (CVE-2023-44487 mitigation)
+
+---
+
+## Scanner configuration reference
+
+Defined in `sec-scanners-config.yaml`:
+
+| Scanner | Type | Scope | Excludes |
+|---|---|---|---|
+| **BDBA** | Container binary scan | Production image | — |
+| **Mend** | Go module SCA | All three `go.mod` graphs | `*_test.go` |
+| **Checkmarx One** | Go SAST | All Go source (`go-default`) | `*_test.go` |

--- a/.claude/rules/go-conventions.md
+++ b/.claude/rules/go-conventions.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go code conventions — runtime-watcher
+
+`make lint` is the authoritative check. The full linter config is in `.golangci.yaml` (run from within each module directory: `listener/` or `runtime-watcher/`).
+
+## nolint policy
+
+Every `//nolint` directive **must** include an explanation:
+```go
+//nolint:funlen // webhook handler — acceptable exception
+```
+Bare suppressions fail CI. Check `.golangci.yaml` before adding any.
+
+## FIPS
+
+Use `GOFIPS140=v1.0.0 go` for any `go` command run directly (the Makefile sets this automatically). Do not add dependencies that bypass the FIPS-approved stdlib crypto.
+
+## TLS — never downgrade
+
+The TLS config in the webhook server contains CVE mitigations. When touching TLS code:
+- Keep `MinVersion: tls.VersionTLS13` — do not lower
+- Keep `NextProtos: []string{"http/1.1"}` — do not add `"h2"` (CVE-2023-44487)
+- Keep mTLS mutual authentication — `InsecureSkipVerify` is not acceptable outside tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,16 @@ The listener serves HTTP on `/v2/{componentName}/event`. Certificate validation 
 - Metrics are Prometheus-based, registered in `watchermetrics/` and `listener/pkg/metrics/`
 - All HTTP retry logic uses `github.com/sethgrid/pester` (exponential backoff) — do not replace with a manual retry loop
 
+## Security guardrails
+
+These constraints are CVE mitigations or compliance requirements — do not remove or weaken them.
+
+- **CVE-2023-44487 (HTTP/2 Rapid Reset)**: `NextProtos: []string{"http/1.1"}` in the TLS config disables HTTP/2 on the webhook server. This is intentional. Do not add `"h2"` to this list.
+- **TLS 1.3 minimum**: The mTLS connection from SKR to KCP uses TLS 1.3. Do not add a `MinVersion` below `tls.VersionTLS13`.
+- **`GOFIPS140=v1.0.0`**: All builds use the FIPS Go module. Never remove this from the Makefile or Dockerfile.
+- **mTLS**: The SKR webhook always authenticates to KCP via mutual TLS. Do not bypass certificate validation in non-test code.
+- **Retry loop**: `github.com/sethgrid/pester` provides exponential backoff. Replacing it with a `for` loop risks thundering-herd amplification under KCP load.
+
 ## Documentation
 
 Detailed docs in `docs/`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,9 @@ Detailed docs in `docs/`:
 - `watcher-setup-guide.md` — configuration and deployment guide
 - `api.md` — Watcher CR API reference
 
+### CVE triage
+Three scanners run against this repo (`sec-scanners-config.yaml`): **Checkmarx One** (SAST), **BDBA** (container CVE scan), **Mend** (Go module SCA across all three modules). When triaging a CVE finding, see [`.claude/cve-triage/context.md`](.claude/cve-triage/context.md).
+
 ## Model usage
 
 Follow the Kyma team's Claude Code workflow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,12 @@ Detailed docs in `docs/`:
 - `listener.md` — how to integrate the listener package in a KCP operator
 - `watcher-setup-guide.md` — configuration and deployment guide
 - `api.md` — Watcher CR API reference
+
+## Model usage
+
+Follow the Kyma team's Claude Code workflow:
+
+- **Planning complex tasks** — switch to Opus: `/model claude-opus-4-7`
+- **Implementation** — use the default Sonnet: `/model claude-sonnet-4-6`
+
+Use Opus when you need to understand an unfamiliar subsystem, design a non-trivial change, or reason about cross-cutting impacts. Switch back to Sonnet once the approach is clear and you are writing code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,7 @@ The listener serves HTTP on `/v2/{componentName}/event`. Certificate validation 
 
 ## Code conventions
 
-- `GOFIPS140=v1.0.0` is used in all build commands
-- **TLS 1.3 is the minimum** — the `NextProtos: []string{"http/1.1"}` configuration in the TLS setup is a CVE-2023-44487 mitigation and must not be removed
-- Metrics are Prometheus-based, registered in `watchermetrics/` and `listener/pkg/metrics/`
-- All HTTP retry logic uses `github.com/sethgrid/pester` (exponential backoff) — do not replace with a manual retry loop
+Go nolint policy, FIPS, and TLS constraint rules load automatically when editing `.go` files — see [`.claude/rules/go-conventions.md`](.claude/rules/go-conventions.md).
 
 ## Security guardrails
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+runtime-watcher is a **two-component system** that reduces Lifecycle Manager's reconciliation load by forwarding only meaningful resource changes from SKR clusters back to KCP. Instead of periodic polling, LKM reacts to real events.
+
+```
+SKR cluster                          KCP cluster
+┌─────────────────────────┐          ┌────────────────────────────┐
+│  runtime-watcher        │  mTLS    │  listener (library)        │
+│  (ValidatingWebhook)    │─────────►│  SKREventListener HTTP srv │
+│  watches configured     │          │  emits GenericEvent on ch  │
+│  resources, detects     │          │  → controller-runtime      │
+│  spec/status changes    │          │    reconcile queue         │
+└─────────────────────────┘          └────────────────────────────┘
+```
+
+## Repo structure — three Go modules
+
+| Directory | Module | Role |
+|---|---|---|
+| `listener/` | `github.com/kyma-project/runtime-watcher/listener` | **Library** consumed by KCP operators (lifecycle-manager) |
+| `runtime-watcher/` | `github.com/kyma-project/runtime-watcher/skr` | **Binary** deployed as a webhook on each SKR |
+| `runtime-watcher/tests/` | `github.com/kyma-project/runtime-watcher/tests` | Shared e2e test suite |
+
+Run `go` and `make` commands from inside the module directory, not from repo root. Root `Makefile` only orchestrates linting across all modules.
+
+## Make targets
+
+### `listener/`
+
+| Target | What it does |
+|---|---|
+| `make test` | Unit tests with race detector |
+| `make lint` | golangci-lint |
+| `make resolve` | `go mod tidy` |
+| `make build-verbose` | Build with verbose output (uses `GOFIPS140=v1.0.0`) |
+
+### `runtime-watcher/`
+
+| Target | What it does |
+|---|---|
+| `make build` | Compile binary with version ldflags |
+| `make test` | Tests with envtest |
+| `make lint` | golangci-lint |
+| `make run` | Run webhook locally |
+| `make docker-build` / `make docker-push` | Container image lifecycle |
+
+### Running a single test
+
+```sh
+# listener
+cd listener && go test -run TestFoo ./pkg/...
+
+# runtime-watcher
+cd runtime-watcher && KUBEBUILDER_ASSETS=$(../bin/setup-envtest use 1.32.0 -p path) \
+  go test -run TestFoo ./...
+```
+
+## listener — key API surface
+
+The listener package is consumed by lifecycle-manager. Its public API:
+
+```go
+// Create and start the listener (implements controller-runtime Runnable)
+listener := event.NewSKREventListener(addr, componentName)
+mgr.Add(listener)
+
+// Receive events in a controller watch
+source.Channel(listener.ReceivedEvents(), &handler.EnqueueRequestForOwner{...})
+```
+
+**`types.WatchEvent`** — the event payload forwarded from SKR:
+```go
+type WatchEvent struct {
+    Watched    ObjectKey               // {Namespace, Name} of the watched resource
+    WatchedGvk metav1.GroupVersionKind // GVK of the watched resource
+    SkrMeta    SkrMeta                 // Runtime ID (from mTLS certificate CN)
+}
+```
+
+The listener serves HTTP on `/v2/{componentName}/event`. Certificate validation (SAN pinning) is optional and passed as a callback — lifecycle-manager uses it to verify the SKR certificate matches the Kyma CR's domain annotation.
+
+## runtime-watcher (SKR webhook) — key behaviour
+
+- Deployed as a `ValidatingWebhookConfiguration` on each SKR via lifecycle-manager's `SKRWebhookManager`
+- Only forwards events when a **spec or status change is detected** (UPDATE operations) — create/delete are always forwarded
+- Sends `WatchEvent` to KCP gateway address over **mTLS** (TLS 1.3 minimum — do not downgrade)
+- Module name is extracted from the webhook URL path: `/validate/{moduleName}`
+
+**Configuration via environment variables** (set by lifecycle-manager when deploying the webhook):
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `WEBHOOK_PORT` | `8443` | Webhook HTTPS port |
+| `METRICS_PORT` | `2112` | Prometheus metrics port |
+| `KCP_ADDR` | — | KCP gateway address |
+| `KCP_CONTRACT` | — | API contract path prefix |
+| `CA_CERT` / `TLS_CERT` / `TLS_KEY` | — | Certificate paths |
+
+## Code conventions
+
+- `GOFIPS140=v1.0.0` is used in all build commands
+- **TLS 1.3 is the minimum** — the `NextProtos: []string{"http/1.1"}` configuration in the TLS setup is a CVE-2023-44487 mitigation and must not be removed
+- Metrics are Prometheus-based, registered in `watchermetrics/` and `listener/pkg/metrics/`
+- All HTTP retry logic uses `github.com/sethgrid/pester` (exponential backoff) — do not replace with a manual retry loop
+
+## Documentation
+
+Detailed docs in `docs/`:
+- `architecture.md` — full system architecture diagram
+- `listener.md` — how to integrate the listener package in a KCP operator
+- `watcher-setup-guide.md` — configuration and deployment guide
+- `api.md` — Watcher CR API reference


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at repo root so every Claude Code session starts with accurate context about this repo
- Covers: the two-component architecture (listener library vs SKR webhook binary), the three Go modules and where to run commands, make targets per module, listener's public API surface (`SKREventListener`, `WatchEvent`, `GenericEvent`), runtime-watcher webhook behaviour, all env vars with defaults, the TLS 1.3 / CVE-2023-44487 constraint, and links to `docs/`

## Motivation

Part of the Jellyfish team initiative to add Claude Code baseline context to all team repos (see kyma-project/lifecycle-manager#3241). This is the runtime-watcher complement to lifecycle-manager#3248.

## Test plan

- [ ] Open a Claude Code session in this repo and confirm `CLAUDE.md` loads with correct module structure and API surface