### PR TITLE
chore: Split build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,7 +1,7 @@
 name: Build Image
 
 permissions:
-  contents: read # This is required for actions/checkout
+  contents: read
 
 on:
   push:
@@ -38,8 +38,8 @@ jobs:
   build-image:
     needs: [get-custom-tags]
     permissions:
-      id-token: write # This is required for requesting the JWT token
-      contents: read # This is required for actions/checkout
+      id-token: write
+      contents: read
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: runtime-watcher

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,7 +1,6 @@
 name: Build Image
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 on:
@@ -15,8 +14,6 @@ on:
         required: false
         type: string
         default: ""
-  pull_request_target:
-    types: [ opened, edited, synchronize, reopened, ready_for_review ]
 
 jobs:
   get-custom-tags:
@@ -25,7 +22,7 @@ jobs:
       tags: ${{ steps.get_custom_tags.outputs.tags }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get tags
         id: get_custom_tags
         run: |
@@ -34,13 +31,15 @@ jobs:
             tags="latest"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             tags="${{ inputs.tag }}"
-          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            tags="${{ github.event.pull_request.head.sha }}"
           fi
           echo "Using custom tags: '$tags'"
           echo "tags=$tags" >> $GITHUB_OUTPUT
+
   build-image:
-    needs: get-custom-tags
+    needs: [get-custom-tags]
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: runtime-watcher

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -1,0 +1,30 @@
+name: Build PR Image
+
+permissions:
+  contents: read # This is required for actions/checkout
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+jobs:
+  restricted-gate:
+    runs-on: ubuntu-latest
+    environment:
+      name: restricted
+    steps:
+      - run: echo "'build-pr-image' job approval granted"
+
+  build-pr-image:
+    needs: restricted-gate
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: runtime-watcher
+      dockerfile: Dockerfile
+      context: ./runtime-watcher
+      # tags are additional tags that will be added to the image on top of the default ones
+      # default tags are documented here: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder#default-tags
+      tags: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -1,7 +1,7 @@
 name: Build PR Image
 
 permissions:
-  contents: read # This is required for actions/checkout
+  contents: read
 
 on:
   pull_request_target:
@@ -18,8 +18,8 @@ jobs:
   build-pr-image:
     needs: restricted-gate
     permissions:
-      id-token: write # This is required for requesting the JWT token
-      contents: read # This is required for actions/checkout
+      id-token: write
+      contents: read
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: runtime-watcher


### PR DESCRIPTION
**Description**

Split the `build-image.yml` workflow into two separate workflows:
- "Build Image" that runs on `push-to-main` and during release builds. This one doesn't need `restricted-gate` protection because an attacker can't inject malicious code (there is no external, untrusted PR involved)
- "Build PR Image" that is triggered on `pull-request-target`. This one needs the `restricted-gate` protection to prevent PR-based workflow poisoning attacks.

This split was necessary because otherwise `push-to-main` runs were also blocked by `restricted-gate`, which is not correct behavior. We could handle it via some conditional logic, but we decided not to: This increases complexity, makes it harder to verify if the solution is secure, adds a chance for an attack based on exploiting potential flaws in the conditional logic. The less logic to fiddle with, the better.

See also: https://github.com/kyma-project/lifecycle-manager/pull/3287 

Changes proposed in this pull request:

- Split the `build-image.yml` workflow into two separate ones.
- Simplify the `build-pr-image` workflow to be minimal
