### PR TITLE
chore: Add `runtime-watcher` tailored `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,6 @@
   "osvVulnerabilityAlerts": true,
   "extends": [
     "config:recommended",
-    ":semanticCommits",
-    ":semanticCommitTypeAll(chore)",
-    ":semanticCommitScopeDisabled",
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["area/dependency", "kind/chore"],
@@ -48,7 +45,6 @@
     {
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["digest"],
-      "schedule": "every month",
       "enabled": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -59,12 +59,12 @@
     {
       "matchManagers": ["gomod"],
       "groupName": "All Kubernetes packages",
-      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"]
     },
     {
       "matchManagers": ["gomod"],
       "groupName": "All Istio packages",
-      "matchPackagePrefixes": ["istio.io/"]
+      "matchPackageNames": ["istio.io/**"]
     },
     {
       "matchManagers": ["gomod"],

--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,10 @@
   },
   "packageRules": [
     {
+      "matchManagers": ["gomod"],
+      "addLabels": ["go"]
+    },
+    {
       "matchCategories": ["golang"],
       "postUpdateOptions": ["gomodTidy"],
       "enabled": true
@@ -71,5 +75,23 @@
       ]
     }
   ],
-  "ignorePaths": ["docs/**", "versions.yaml"]
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["^versions\\.yaml$"],
+      "matchStrings": ["golangciLint: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "golangci/golangci-lint"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["^versions\\.yaml$"],
+      "matchStrings": ["envtest_k8s: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kubernetes/kubernetes"
+    }
+  ],
+  "ignorePaths": ["docs/**"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["area/dependency", "kind/chore"],
+  "commitMessagePrefix": "chore(renovate):",
   "gomod": {
     "postUpdateOptions": ["gomodTidy"],
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,74 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "osvVulnerabilityAlerts": true,
   "extends": [
-    "config:recommended"
-  ]
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScopeDisabled",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "labels": ["area/dependency", "kind/chore"],
+  "gomod": {
+    "postUpdateOptions": ["gomodTidy"],
+    "enabled": true
+  },
+  "kustomize": {
+    "enabled": false
+  },
+  "dockerfile": {
+    "enabled": true
+  },
+  "helm-values": {
+    "enabled": false
+  },
+  "github-actions": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchCategories": ["golang"],
+      "postUpdateOptions": ["gomodTidy"],
+      "enabled": true
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": "every month",
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All Kubernetes packages",
+      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All Istio packages",
+      "matchPackagePrefixes": ["istio.io/"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "ginkgo and gomega",
+      "matchPackageNames": [
+        "github.com/onsi/ginkgo/v2",
+        "github.com/onsi/gomega"
+      ]
+    }
+  ],
+  "ignorePaths": ["docs/**", "versions.yaml"]
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,3 +1,3 @@
 golangciLint: "2.9.0"
-envtest: "0.21"
+envtest: "0.21" # tracks controller-runtime minor version (sigs.k8s.io/controller-runtime/tools/setup-envtest@release-<minor>); bump manually alongside controller-runtime upgrades
 envtest_k8s: "1.32.0"


### PR DESCRIPTION
**Description**

Here I introduce `renovate.json` tailored for `runtime-watcher`.

**Related issue(s)**
[Lifecycle Manager Issue 2995](https://github.com/kyma-project/lifecycle-manager/issues/2995)