### PR TITLE
fix: Prevent `image-builder` Pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,7 +74,21 @@
     },
     {
       "matchManagers": ["gomod"],
-      "groupName": "Go maintenance"
+      "groupName": "All Kubernetes packages",
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All Istio packages",
+      "matchPackageNames": ["istio.io/**"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All ginkgo and gomega packages",
+      "matchPackageNames": [
+        "github.com/onsi/ginkgo/v2",
+        "github.com/onsi/gomega"
+      ]
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
         ".github/workflows/build-image.yml",
         ".github/workflows/build-pr-image.yml"
       ],
-      "enabled": false
+      "pinDigests": false
     },
     {
       "matchManagers": ["gomod"],

--- a/renovate.json
+++ b/renovate.json
@@ -35,10 +35,6 @@
       "pinDigests": false
     },
     {
-      "matchManagers": ["dockerfile"],
-      "groupName": "Docker maintenance"
-    },
-    {
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["digest"],
       "automerge": true
@@ -88,6 +84,14 @@
         "github.com/onsi/ginkgo/v2",
         "github.com/onsi/gomega"
       ]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go maintenance"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker maintenance"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
   "labels": ["area/dependency", "kind/chore"],
   "commitMessagePrefix": "chore(renovate):",
+  "minimumReleaseAge": "3 days",
   "gomod": {
     "postUpdateOptions": ["gomodTidy"],
     "enabled": true
@@ -15,7 +16,8 @@
     "enabled": false
   },
   "dockerfile": {
-    "enabled": true
+    "enabled": true,
+    "pinDigests": true
   },
   "helm-values": {
     "enabled": false
@@ -32,6 +34,15 @@
         ".github/workflows/build-pr-image.yml"
       ],
       "pinDigests": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker maintenance"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
     },
     {
       "matchManagers": ["gomod"],
@@ -63,21 +74,7 @@
     },
     {
       "matchManagers": ["gomod"],
-      "groupName": "All Kubernetes packages",
-      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"]
-    },
-    {
-      "matchManagers": ["gomod"],
-      "groupName": "All Istio packages",
-      "matchPackageNames": ["istio.io/**"]
-    },
-    {
-      "matchManagers": ["gomod"],
-      "groupName": "ginkgo and gomega",
-      "matchPackageNames": [
-        "github.com/onsi/ginkgo/v2",
-        "github.com/onsi/gomega"
-      ]
+      "groupName": "Go maintenance"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,6 @@
     "enabled": false
   },
   "dockerfile": {
-    "enabled": true,
     "pinDigests": true
   },
   "helm-values": {

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,15 @@
   },
   "packageRules": [
     {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["kyma-project/test-infra"],
+      "matchFileNames": [
+        ".github/workflows/build-image.yml",
+        ".github/workflows/build-pr-image.yml"
+      ],
+      "enabled": false
+    },
+    {
       "matchManagers": ["gomod"],
       "addLabels": ["go"]
     },


### PR DESCRIPTION
**Description**

For security / technical reasons, when having the SHA hash of `kyma-project/test-infra` `image-builder` on the GitHub Workflow files, it's not able to fetch the secret anymore. Only having a `@main` allows it to fetch the secret.

**Changes proposed in this pull request:**

- To mitigate this, a rule exception to bypass exactly the `kyma-project/test-infra` `image-builder` dependency has been introduced.
- `Dockerfile` digest pinning
- Setting `minimumReleaseAge` to 3 days