### PR TITLE
chore: Bump go version to `1.26.5`

### DIFF
--- a/listener/go.mod
+++ b/listener/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/listener
 
-go 1.26.4
+go 1.26.5
 
 retract v1.1.18 // reason: not a valid release
 

--- a/runtime-watcher/Dockerfile
+++ b/runtime-watcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 WORKDIR /app
 

--- a/runtime-watcher/go.mod
+++ b/runtime-watcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/skr
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/runtime-watcher/tests/go.mod
+++ b/runtime-watcher/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/runtime-watcher/tests
 
-go 1.26.4
+go 1.26.5
 
 replace (
 	github.com/kyma-project/runtime-watcher/listener => ../../listener


### PR DESCRIPTION
**Description**

Bump go version to `1.26.5`

Changes proposed in this pull request:

- Updated `go.mod` files
- Updated Dockerfile
