### PR TITLE
feat: Use local actions instead of references for actions removed from `lifecycle-manager`

### DIFF
--- a/.github/actions/deploy-lifecycle-manager/action.yml
+++ b/.github/actions/deploy-lifecycle-manager/action.yml
@@ -1,0 +1,39 @@
+name: Deploy lifecycle-manager
+description: Deploys lifecycle-manager.
+inputs:
+  klm_version_tag:
+    description: The version tag for the KLM image. For example, PR-123.
+    required: true
+  klm_image_repo:
+    description: The repository for the KLM image. For example, dev.
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: .github/actions/switch-kubectl-context 
+      with:
+        context_name: k3d-kcp
+    - name: Deploy LM local testing kustomize
+      working-directory: lifecycle-manager
+      shell: bash
+      run: |
+        if [[ -n "${E2E_USE_GARDENER_CERT_MANAGER}" ]]; then
+          E2E_MAKE_TARGET=local-deploy-with-watcher-gcm
+        else
+          E2E_MAKE_TARGET=local-deploy-with-watcher
+        fi
+        maxRetry=5
+        for retry in $(seq 1 $maxRetry)
+        do
+          if make "$E2E_MAKE_TARGET" IMG=europe-docker.pkg.dev/kyma-project/${{ inputs.klm_image_repo }}/lifecycle-manager:${{ inputs.klm_version_tag }}; then
+            kubectl wait pods -n kcp-system -l app.kubernetes.io/name=lifecycle-manager --for condition=Ready --timeout=150s
+            echo "KLM deployed successfully"
+            exit 0
+          elif [[ $retry -lt $maxRetry ]]; then
+            echo "Deploy encountered some error, will retry after 20 seconds"
+            sleep 20
+          else
+            echo "KLM deployment failed"
+            exit 1
+          fi
+        done

--- a/.github/actions/deploy-lifecycle-manager/action.yml
+++ b/.github/actions/deploy-lifecycle-manager/action.yml
@@ -17,11 +17,7 @@ runs:
       working-directory: lifecycle-manager
       shell: bash
       run: |
-        if [[ -n "${E2E_USE_GARDENER_CERT_MANAGER}" ]]; then
-          E2E_MAKE_TARGET=local-deploy-with-watcher-gcm
-        else
-          E2E_MAKE_TARGET=local-deploy-with-watcher
-        fi
+        E2E_MAKE_TARGET=local-deploy-with-watcher
         maxRetry=5
         for retry in $(seq 1 $maxRetry)
         do

--- a/.github/actions/deploy-lifecycle-manager/action.yml
+++ b/.github/actions/deploy-lifecycle-manager/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: .github/actions/switch-kubectl-context 
+    - uses: ./.github/actions/switch-kubectl-context 
       with:
         context_name: k3d-kcp
     - name: Deploy LM local testing kustomize

--- a/.github/actions/export-kubeconfigs/action.yml
+++ b/.github/actions/export-kubeconfigs/action.yml
@@ -1,0 +1,15 @@
+name: Export kubeconfigs
+description: Merges the configs from KCP and SKR k3d clusters into the default kubeconfig and exports the same as environment variables KCP_KUBECONFIG and SKR_KUBECONFIG.
+inputs:
+  context_name:
+    description: The name of the context to use.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Export kubeconfigs
+      shell: bash
+      run: |
+        k3d kubeconfig merge -a -d
+        echo "KCP_KUBECONFIG=$(k3d kubeconfig write kcp)" >> $GITHUB_ENV
+        echo "SKR_KUBECONFIG=$(k3d kubeconfig write skr)" >> $GITHUB_ENV

--- a/.github/actions/setup-test-clusters/action.yml
+++ b/.github/actions/setup-test-clusters/action.yml
@@ -1,0 +1,22 @@
+name: Setup test clusters
+description: Creates and configures the KCP and SKR clusters.
+inputs:
+  k8s_version:
+    description: The version of k8s to use. For example, 1.28.7
+    required: true
+  cert_manager_version:
+    description: The version of cert-manager to depoy. For example, 1.13.3.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: create-test-clusters
+      shell: bash
+      run: |
+        ./lifecycle-manager/scripts/tests/create_test_clusters.sh --k8s-version ${{ inputs.k8s_version }} --cert-manager-version ${{ inputs.cert_manager_version }}
+
+    - uses: ./.github/actions/export-kubeconfigs
+
+    - uses: ./.github/actions/switch-kubectl-context
+      with:
+        context_name: k3d-kcp

--- a/.github/actions/switch-kubectl-context/action.yml
+++ b/.github/actions/switch-kubectl-context/action.yml
@@ -1,0 +1,13 @@
+name: Switch kubectl context
+description: Switches kubectl to use the context with the provided name.
+inputs:
+  context_name:
+    description: The name of the context to use.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Configure kubectl
+      shell: bash
+      run: |
+        kubectl config use-context ${{ inputs.context_name }}

--- a/.github/workflows/test-e2e-runtime-watcher.yml
+++ b/.github/workflows/test-e2e-runtime-watcher.yml
@@ -113,7 +113,7 @@ jobs:
           cache-dependency-path: runtime-watcher/go.sum
 
       - name: Setup test clusters
-        uses: kyma-project/lifecycle-manager/.github/actions/setup-test-clusters@2253deaa87f94e6857b32d2637f261904538bac5 # main
+        uses: ./.github/actions/setup-test-clusters
         with:
           k8s_version: ${{ steps.configuration.outputs.k8s_version }}
           cert_manager_version: ${{ steps.configuration.outputs.cert_manager_version }}
@@ -129,7 +129,7 @@ jobs:
           runtime-watcher-image-registry: ${{ needs.get-image-repo.outputs.image_repo }}
 
       - name: Deploy lifecycle-manager
-        uses: kyma-project/lifecycle-manager/.github/actions/deploy-lifecycle-manager@2253deaa87f94e6857b32d2637f261904538bac5 # main
+        uses: ./.github/actions/deploy-lifecycle-manager
         with:
           klm_version_tag: latest
           klm_image_repo: prod


### PR DESCRIPTION
**Description**

Use local actions instead of references to actions defined in `lifecycle-manager` repository for those actions that have been removed from `lifecycle-manager` because of https://github.com/kyma-project/lifecycle-manager/pull/3433

Changes proposed in this pull request:

- Add local actions for the actions that no longer exist in `lifecycle-manager` repository `main` branch
- Update workflow `test-e2e-runtime-watcher.yml` accordingly

**Related issue(s)**
Fixes: #806 